### PR TITLE
feat: add file-based lock mechanism for concurrent install protection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,6 +433,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1852,6 +1862,7 @@ dependencies = [
  "dialoguer",
  "dirs",
  "flate2",
+ "fs2",
  "indicatif",
  "reqwest",
  "serde",
@@ -2028,6 +2039,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2035,6 +2062,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,9 @@ thiserror = "2"
 # 交互式选择
 dialoguer = "0.12"
 
+# 文件锁
+fs2 = "0.4"
+
 # The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,6 +30,9 @@ pub enum VexError {
 
     #[error("Dialog error: {0}")]
     Dialog(String),
+
+    #[error("Another vex process is installing {tool}@{version}. Please wait and try again.")]
+    LockConflict { tool: String, version: String },
 }
 
 pub type Result<T> = std::result::Result<T, VexError>;
@@ -103,5 +106,17 @@ mod tests {
             path: PathBuf::from("/usr/local/bin"),
         };
         assert_eq!(err.to_string(), "Permission denied: /usr/local/bin");
+    }
+
+    #[test]
+    fn test_error_display_lock_conflict() {
+        let err = VexError::LockConflict {
+            tool: "node".to_string(),
+            version: "20.11.0".to_string(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "Another vex process is installing node@20.11.0. Please wait and try again."
+        );
     }
 }

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -1,5 +1,6 @@
 use crate::downloader::{download_with_retry, verify_checksum};
 use crate::error::{Result, VexError};
+use crate::lock::InstallLock;
 use crate::tools::{Arch, Tool};
 use flate2::read::GzDecoder;
 use std::fs;
@@ -59,6 +60,9 @@ pub fn install(tool: &dyn Tool, version: &str) -> Result<()> {
         println!("Use 'vex use {}@{}' to switch to it.", tool.name(), version);
         return Ok(());
     }
+
+    // Acquire install lock (fail fast if another process is installing the same version)
+    let _lock = InstallLock::acquire(&vex, tool.name(), version)?;
 
     println!("Installing {} {}...", tool.name(), version);
 

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -1,0 +1,208 @@
+use crate::error::{Result, VexError};
+use fs2::FileExt;
+use std::fs::{self, File};
+use std::path::{Path, PathBuf};
+
+/// RAII-based install lock using file-based exclusive locking.
+/// Automatically releases the lock and cleans up the lock file on drop.
+pub struct InstallLock {
+    file: File,
+    path: PathBuf,
+}
+
+impl InstallLock {
+    /// Acquire an exclusive lock for installing a specific tool version.
+    /// Fails fast with LockConflict if another process holds the lock.
+    pub fn acquire(vex_dir: &Path, tool: &str, version: &str) -> Result<Self> {
+        let locks_dir = vex_dir.join("locks");
+        fs::create_dir_all(&locks_dir)?;
+
+        let lock_filename = format!("{}-{}.lock", tool, version);
+        let lock_path = locks_dir.join(lock_filename);
+
+        let file = File::create(&lock_path)?;
+
+        // Non-blocking exclusive lock
+        if file.try_lock_exclusive().is_err() {
+            return Err(VexError::LockConflict {
+                tool: tool.to_string(),
+                version: version.to_string(),
+            });
+        }
+
+        Ok(Self {
+            file,
+            path: lock_path,
+        })
+    }
+}
+
+impl Drop for InstallLock {
+    fn drop(&mut self) {
+        let _ = self.file.unlock();
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    /// Each test gets its own unique temp directory to avoid parallel interference.
+    fn unique_vex_dir() -> PathBuf {
+        let id = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
+        let dir = std::env::temp_dir().join(format!("vex-lock-test-{}-{}", std::process::id(), id));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn test_lock_acquire_success() {
+        let vex_dir = unique_vex_dir();
+        let lock = InstallLock::acquire(&vex_dir, "node", "20.11.0");
+        assert!(lock.is_ok());
+        let _ = fs::remove_dir_all(&vex_dir);
+    }
+
+    #[test]
+    fn test_lock_file_created() {
+        let vex_dir = unique_vex_dir();
+        let lock_path = vex_dir.join("locks").join("go-1.23.5.lock");
+
+        let _lock = InstallLock::acquire(&vex_dir, "go", "1.23.5").unwrap();
+        assert!(lock_path.exists());
+
+        let _ = fs::remove_dir_all(&vex_dir);
+    }
+
+    #[test]
+    fn test_lock_cleanup_on_drop() {
+        let vex_dir = unique_vex_dir();
+        let lock_path = vex_dir.join("locks").join("node-18.0.0.lock");
+
+        {
+            let _lock = InstallLock::acquire(&vex_dir, "node", "18.0.0").unwrap();
+            assert!(lock_path.exists());
+        }
+
+        // Lock file removed after drop
+        assert!(!lock_path.exists());
+        let _ = fs::remove_dir_all(&vex_dir);
+    }
+
+    #[test]
+    fn test_lock_reacquire_after_drop() {
+        let vex_dir = unique_vex_dir();
+
+        {
+            let _lock = InstallLock::acquire(&vex_dir, "rust", "1.93.1").unwrap();
+        }
+
+        // Should succeed after previous lock is dropped
+        let lock2 = InstallLock::acquire(&vex_dir, "rust", "1.93.1");
+        assert!(lock2.is_ok());
+        let _ = fs::remove_dir_all(&vex_dir);
+    }
+
+    #[test]
+    fn test_different_versions_no_conflict() {
+        let vex_dir = unique_vex_dir();
+
+        let _lock1 = InstallLock::acquire(&vex_dir, "node", "20.11.0").unwrap();
+        let lock2 = InstallLock::acquire(&vex_dir, "node", "18.19.0");
+
+        assert!(lock2.is_ok());
+        let _ = fs::remove_dir_all(&vex_dir);
+    }
+
+    #[test]
+    fn test_different_tools_no_conflict() {
+        let vex_dir = unique_vex_dir();
+
+        let _lock1 = InstallLock::acquire(&vex_dir, "node", "20.11.0").unwrap();
+        let lock2 = InstallLock::acquire(&vex_dir, "go", "1.23.5");
+
+        assert!(lock2.is_ok());
+        let _ = fs::remove_dir_all(&vex_dir);
+    }
+
+    /// Cross-process lock conflict test.
+    /// Spawns a child process that holds a lock, then verifies the parent
+    /// cannot acquire the same lock.
+    #[test]
+    fn test_cross_process_lock_conflict() {
+        let vex_dir = unique_vex_dir();
+        let locks_dir = vex_dir.join("locks");
+        fs::create_dir_all(&locks_dir).unwrap();
+
+        let lock_path = locks_dir.join("node-22.0.0.lock");
+
+        // Child process: Python script that acquires exclusive lock and signals readiness
+        let python_script = format!(
+            r#"
+import fcntl
+import sys
+import time
+
+with open('{}', 'w') as f:
+    fcntl.flock(f.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    print('ready', flush=True)
+    time.sleep(30)
+"#,
+            lock_path.display()
+        );
+
+        let mut child = std::process::Command::new("/usr/bin/python3")
+            .arg("-c")
+            .arg(&python_script)
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .expect("failed to spawn child");
+
+        // Wait for child to signal it holds the lock
+        use std::io::Read;
+        let stdout = child.stdout.as_mut().unwrap();
+        let mut buf = [0u8; 6];
+        let mut total = 0;
+        while total < 5 {
+            let n = stdout.read(&mut buf[total..]).unwrap();
+            if n == 0 {
+                break;
+            }
+            total += n;
+        }
+        assert!(
+            std::str::from_utf8(&buf[..total])
+                .unwrap()
+                .starts_with("ready"),
+            "child did not acquire lock"
+        );
+
+        // Now try to acquire the same lock from this process - should fail
+        let file = File::create(&lock_path).unwrap();
+        let result = file.try_lock_exclusive();
+        assert!(result.is_err(), "Expected lock conflict with child process");
+
+        // Cleanup
+        child.kill().ok();
+        child.wait().ok();
+        let _ = fs::remove_dir_all(&vex_dir);
+    }
+
+    #[test]
+    fn test_locks_dir_auto_created() {
+        let vex_dir = unique_vex_dir();
+        let locks_dir = vex_dir.join("locks");
+
+        // locks/ doesn't exist yet
+        assert!(!locks_dir.exists());
+
+        let _lock = InstallLock::acquire(&vex_dir, "java", "21").unwrap();
+        assert!(locks_dir.exists());
+
+        let _ = fs::remove_dir_all(&vex_dir);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 mod downloader;
 mod error;
 mod installer;
+mod lock;
 mod resolver;
 mod shell;
 mod switcher;


### PR DESCRIPTION
## Changes

- Implement InstallLock with RAII pattern using fs2 file locks
- Fail fast on lock conflict with clear error message
- Auto-cleanup lock files on drop
- Add LockConflict error variant

## Lock Strategy

Uses **fail-fast** (non-blocking): if another vex process is installing the same tool@version, immediately returns an error instead of waiting. This avoids user confusion and deadlock risks.

## New Dependencies

- fs2 = "0.4"

## Testing

- 8 new lock unit tests (including cross-process conflict detection)
- All 106 tests pass
- cargo clippy clean, cargo fmt clean