### PR TITLE
fix: include corepack in Node.js bin_names

### DIFF
--- a/src/tools/node.rs
+++ b/src/tools/node.rs
@@ -71,7 +71,7 @@ impl Tool for NodeTool {
     }
 
     fn bin_names(&self) -> Vec<&str> {
-        vec!["node", "npm", "npx"]
+        vec!["node", "npm", "npx", "corepack"]
     }
 
     fn bin_subpath(&self) -> &str {
@@ -170,7 +170,7 @@ mod tests {
     #[test]
     fn test_bin_names() {
         let tool = NodeTool;
-        assert_eq!(tool.bin_names(), vec!["node", "npm", "npx"]);
+        assert_eq!(tool.bin_names(), vec!["node", "npm", "npx", "corepack"]);
     }
 
     #[test]
@@ -185,7 +185,12 @@ mod tests {
         let paths = tool.bin_paths();
         assert_eq!(
             paths,
-            vec![("node", "bin"), ("npm", "bin"), ("npx", "bin"),]
+            vec![
+                ("node", "bin"),
+                ("npm", "bin"),
+                ("npx", "bin"),
+                ("corepack", "bin"),
+            ]
         );
     }
 


### PR DESCRIPTION
## 问题

安装 Node.js 后 `corepack` 命令不可用，导致无法使用 `corepack enable pnpm` 激活 pnpm。

## 根因

Node.js 官方发行包从 v16 开始内置 `corepack` 二进制文件，但 `src/tools/node.rs` 的 `bin_names()` 只声明了 `["node", "npm", "npx"]`，漏掉了 `corepack`。vex 的 switcher 根据 `bin_names()` 创建符号链接，所以 `~/.vex/bin/` 里没有 `corepack`。

## 修复

- 在 `bin_names()` 中添加 `"corepack"`
- 同步更新相关单元测试

## 测试

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all-features
```

所有检查通过（110 个测试，零警告）。