### PR TITLE
fix: change install path from ~/.cargo/bin to ~/.local/bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 
 #### One-line installer (Recommended)
 
-Automatically downloads the correct prebuilt binary for your macOS architecture (`arm64`/`x86_64`), installs to `~/.cargo/bin/vex`, and updates shell PATH in `~/.zshrc`, `~/.bashrc`, and `~/.bash_profile`:
+Automatically downloads the correct prebuilt binary for your macOS architecture (`arm64`/`x86_64`), installs to `~/.local/bin/vex`, and updates your shell PATH configuration:
 
 ```bash
 # Latest release
@@ -83,12 +83,12 @@ Extract and install:
 
 ```bash
 tar -xzf vex-*.tar.gz
-mkdir -p ~/.cargo/bin
-cp vex-*/vex ~/.cargo/bin/vex
-chmod +x ~/.cargo/bin/vex
+mkdir -p ~/.local/bin
+cp vex-*/vex ~/.local/bin/vex
+chmod +x ~/.local/bin/vex
 
 # Add to PATH if not already present
-echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> ~/.zshrc
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
 source ~/.zshrc
 ```
 
@@ -97,7 +97,7 @@ source ~/.zshrc
 ```bash
 git clone https://github.com/imnotnoahhh/vex.git
 cd vex
-cargo build --release && cp target/release/vex ~/.cargo/bin/vex
+cargo build --release && cp target/release/vex ~/.local/bin/vex
 ```
 
 Verify installation:


### PR DESCRIPTION
## 问题

安装脚本将 vex 安装到 `~/.cargo/bin/vex`，存在以下问题：

1. **语义混乱** — vex 不是 cargo 工具，却放在 cargo 的目录里
2. **循环依赖感** — vex 本身是用来管理 Rust 等工具链的，结果自己却依赖 cargo 的目录结构
3. **过度修改** — 脚本会同时修改 `.zshrc`、`.bashrc`、`.bash_profile`，即使用户只用其中一个 shell

## 修复

1. **改用 `~/.local/bin`**
   - 符合 XDG 标准的用户二进制目录
   - 语义正确，不依赖任何特定工具链
   - 现代工具的常见选择（mise、uv 等）

2. **智能检测 shell**
   - 通过 `$SHELL` 环境变量检测当前使用的 shell
   - 只修改对应的配置文件（zsh → `.zshrc`，bash → `.bash_profile` 或 `.bashrc`）
   - 避免污染未使用的配置文件

## 变更

- `scripts/install-release.sh`: 安装路径改为 `~/.local/bin`，添加 shell 检测逻辑
- `README.md`: 同步更新所有安装路径示例