### PR TITLE
feat: prompt user to configure shell integration during install

### DIFF
--- a/scripts/install-release.sh
+++ b/scripts/install-release.sh
@@ -152,11 +152,30 @@ if [ -n "$RC_FILE" ]; then
 fi
 
 log "Installed vex $TAG_NAME to $INSTALL_PATH"
-log "Run 'vex --version' to verify installation."
 
+# Ask user whether to configure shell integration
 if [ -n "$RC_FILE" ]; then
-  log "Reload your shell config to use vex:"
-  log "  source $RC_FILE"
+  HOOK_LINE="eval \"\$(vex env $CURRENT_SHELL)\""
+
+  if grep -Fqs "$HOOK_LINE" "$RC_FILE"; then
+    log "Shell integration already configured in $RC_FILE"
+  elif [ -t 0 ] || [ -e /dev/tty ]; then
+    printf 'Configure shell integration in %s? [Y/n] ' "$RC_FILE"
+    read -r REPLY < /dev/tty 2>/dev/null || REPLY="n"
+    case "$REPLY" in
+      [nN]*)
+        log "Skipped. Run 'vex init' later to set up shell integration."
+        ;;
+      *)
+        printf '\n%s\n' "$HOOK_LINE" >> "$RC_FILE"
+        log "Added shell integration to $RC_FILE"
+        log "Reload to activate:"
+        log "  source $RC_FILE"
+        ;;
+    esac
+  else
+    log "Run 'vex init' to set up shell integration."
+  fi
 else
-  log "Add $INSTALL_DIR to your PATH manually to use vex."
+  log "Run 'vex init' to set up shell integration."
 fi


### PR DESCRIPTION
## 问题

安装脚本只把 vex 二进制放到 `~/.local/bin`，但不配置 shell hook。用户装完后 `~/.vex/bin` 不在 PATH 里，通过 vex 安装的工具（node、go、rustc 等）全部找不到，还得手动跑 `vex init`。

## 修复

安装完成后交互式询问用户是否配置 shell integration：

- 输入 Y（默认）：自动把 `eval "$(vex env zsh/bash)"` 写入对应的 rc 文件
- 输入 n：提示用户后续运行 `vex init`
- 已配置过：跳过，提示已存在
- 非交互环境（无 tty）：提示运行 `vex init`

通过 `/dev/tty` 读取输入，兼容 `curl | bash` 管道执行方式。