### PR TITLE
fix: complete bin_names for Java JDK and add rust-analyzer

### DIFF
--- a/src/switcher.rs
+++ b/src/switcher.rs
@@ -143,15 +143,18 @@ mod tests {
         let cargo_dir = base.join("toolchains/rust/1.93.1/cargo/bin");
         let rustfmt_dir = base.join("toolchains/rust/1.93.1/rustfmt-preview/bin");
         let clippy_dir = base.join("toolchains/rust/1.93.1/clippy-preview/bin");
+        let analyzer_dir = base.join("toolchains/rust/1.93.1/rust-analyzer-preview/bin");
         fs::create_dir_all(&rustc_dir).unwrap();
         fs::create_dir_all(&cargo_dir).unwrap();
         fs::create_dir_all(&rustfmt_dir).unwrap();
         fs::create_dir_all(&clippy_dir).unwrap();
+        fs::create_dir_all(&analyzer_dir).unwrap();
         fs::write(rustc_dir.join("rustc"), "fake").unwrap();
         fs::write(cargo_dir.join("cargo"), "fake").unwrap();
         fs::write(rustfmt_dir.join("rustfmt"), "fake").unwrap();
         fs::write(rustfmt_dir.join("cargo-fmt"), "fake").unwrap();
         fs::write(clippy_dir.join("cargo-clippy"), "fake").unwrap();
+        fs::write(analyzer_dir.join("rust-analyzer"), "fake").unwrap();
 
         let result = switch_version_in(&RustTool, "1.93.1", &base);
         assert!(result.is_ok());
@@ -162,10 +165,11 @@ mod tests {
         assert!(rustc_target.to_string_lossy().contains("rustc/bin/rustc"));
         assert!(cargo_target.to_string_lossy().contains("cargo/bin/cargo"));
 
-        // 验证 clippy 和 rustfmt 链接
+        // 验证 clippy、rustfmt、rust-analyzer 链接
         assert!(base.join("bin/rustfmt").exists());
         assert!(base.join("bin/cargo-fmt").exists());
         assert!(base.join("bin/cargo-clippy").exists());
+        assert!(base.join("bin/rust-analyzer").exists());
 
         let _ = fs::remove_dir_all(&base);
     }

--- a/src/tools/java.rs
+++ b/src/tools/java.rs
@@ -105,7 +105,38 @@ impl Tool for JavaTool {
     }
 
     fn bin_names(&self) -> Vec<&str> {
-        vec!["java", "javac", "jar"]
+        vec![
+            "java",
+            "javac",
+            "jar",
+            "javadoc",
+            "javap",
+            "jcmd",
+            "jconsole",
+            "jdb",
+            "jdeprscan",
+            "jdeps",
+            "jfr",
+            "jhsdb",
+            "jimage",
+            "jinfo",
+            "jlink",
+            "jmap",
+            "jmod",
+            "jnativescan",
+            "jpackage",
+            "jps",
+            "jrunscript",
+            "jshell",
+            "jstack",
+            "jstat",
+            "jstatd",
+            "jwebserver",
+            "keytool",
+            "rmiregistry",
+            "serialver",
+            "jarsigner",
+        ]
     }
 
     fn bin_subpath(&self) -> &str {
@@ -165,7 +196,14 @@ mod tests {
 
     #[test]
     fn test_bin_names() {
-        assert_eq!(JavaTool.bin_names(), vec!["java", "javac", "jar"]);
+        let names = JavaTool.bin_names();
+        assert!(names.contains(&"java"));
+        assert!(names.contains(&"javac"));
+        assert!(names.contains(&"jar"));
+        assert!(names.contains(&"javadoc"));
+        assert!(names.contains(&"jshell"));
+        assert!(names.contains(&"keytool"));
+        assert_eq!(names.len(), 30);
     }
 
     #[test]
@@ -176,14 +214,11 @@ mod tests {
     #[test]
     fn test_bin_paths_default() {
         let paths = JavaTool.bin_paths();
-        assert_eq!(
-            paths,
-            vec![
-                ("java", "Contents/Home/bin"),
-                ("javac", "Contents/Home/bin"),
-                ("jar", "Contents/Home/bin"),
-            ]
-        );
+        // All binaries share the same subpath
+        assert_eq!(paths.len(), 30);
+        for (_, subpath) in &paths {
+            assert_eq!(*subpath, "Contents/Home/bin");
+        }
     }
 
     #[test]

--- a/src/tools/rust.rs
+++ b/src/tools/rust.rs
@@ -76,7 +76,14 @@ impl Tool for RustTool {
     }
 
     fn bin_names(&self) -> Vec<&str> {
-        vec!["rustc", "cargo", "rustfmt", "cargo-fmt", "cargo-clippy"]
+        vec![
+            "rustc",
+            "cargo",
+            "rustfmt",
+            "cargo-fmt",
+            "cargo-clippy",
+            "rust-analyzer",
+        ]
     }
 
     fn bin_subpath(&self) -> &str {
@@ -84,13 +91,13 @@ impl Tool for RustTool {
     }
 
     fn bin_paths(&self) -> Vec<(&str, &str)> {
-        // Rust tarball 中 rustc 和 cargo 在不同子目录
         vec![
             ("rustc", "rustc/bin"),
             ("cargo", "cargo/bin"),
             ("rustfmt", "rustfmt-preview/bin"),
             ("cargo-fmt", "rustfmt-preview/bin"),
             ("cargo-clippy", "clippy-preview/bin"),
+            ("rust-analyzer", "rust-analyzer-preview/bin"),
         ]
     }
 
@@ -148,10 +155,10 @@ impl Tool for RustTool {
             unix_fs::symlink(&std_src, &std_dst)?;
         }
 
-        // 2. 链接 rustc/lib 到 clippy-preview/lib 和 rustfmt-preview/lib
-        //    这些工具通过 @rpath (../lib/) 查找 librustc_driver
+        // 2. 链接 rustc/lib 到各组件目录
+        //    clippy/rustfmt/rust-analyzer 通过 @rpath (../lib/) 查找 librustc_driver
         let rustc_lib = install_dir.join("rustc/lib");
-        for component in &["clippy-preview", "rustfmt-preview"] {
+        for component in &["clippy-preview", "rustfmt-preview", "rust-analyzer-preview"] {
             let lib_link = install_dir.join(component).join("lib");
             if rustc_lib.exists() && !lib_link.exists() {
                 unix_fs::symlink(&rustc_lib, &lib_link)?;
@@ -176,7 +183,14 @@ mod tests {
     fn test_bin_names() {
         assert_eq!(
             RustTool.bin_names(),
-            vec!["rustc", "cargo", "rustfmt", "cargo-fmt", "cargo-clippy"]
+            vec![
+                "rustc",
+                "cargo",
+                "rustfmt",
+                "cargo-fmt",
+                "cargo-clippy",
+                "rust-analyzer",
+            ]
         );
     }
 
@@ -196,6 +210,7 @@ mod tests {
                 ("rustfmt", "rustfmt-preview/bin"),
                 ("cargo-fmt", "rustfmt-preview/bin"),
                 ("cargo-clippy", "clippy-preview/bin"),
+                ("rust-analyzer", "rust-analyzer-preview/bin"),
             ]
         );
     }


### PR DESCRIPTION
## Summary

Completes binary coverage for Java and Rust toolchains:

**Java JDK** — Expanded from 3 to all 30 executables:
- Previously: `java`, `javac`, `jar`
- Now includes: `javadoc`, `javap`, `jshell`, `jlink`, `jpackage`, `jcmd`, `jps`, `jstack`, `jmap`, `keytool`, and 20 more

**Rust** — Added `rust-analyzer`:
- Language server for IDE integration
- Added to `bin_paths()` with `rust-analyzer-preview/bin` path
- Updated `post_install()` to create lib symlink for @rpath resolution

## Testing

- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` ✅  
- `cargo test` — 121 tests passed (95 unit + 26 CLI integration)