### PR TITLE
fix: add missing Rust binaries

### DIFF
--- a/src/switcher.rs
+++ b/src/switcher.rs
@@ -150,10 +150,15 @@ mod tests {
         fs::create_dir_all(&clippy_dir).unwrap();
         fs::create_dir_all(&analyzer_dir).unwrap();
         fs::write(rustc_dir.join("rustc"), "fake").unwrap();
+        fs::write(rustc_dir.join("rustdoc"), "fake").unwrap();
+        fs::write(rustc_dir.join("rust-gdb"), "fake").unwrap();
+        fs::write(rustc_dir.join("rust-gdbgui"), "fake").unwrap();
+        fs::write(rustc_dir.join("rust-lldb"), "fake").unwrap();
         fs::write(cargo_dir.join("cargo"), "fake").unwrap();
         fs::write(rustfmt_dir.join("rustfmt"), "fake").unwrap();
         fs::write(rustfmt_dir.join("cargo-fmt"), "fake").unwrap();
         fs::write(clippy_dir.join("cargo-clippy"), "fake").unwrap();
+        fs::write(clippy_dir.join("clippy-driver"), "fake").unwrap();
         fs::write(analyzer_dir.join("rust-analyzer"), "fake").unwrap();
 
         let result = switch_version_in(&RustTool, "1.93.1", &base);
@@ -169,7 +174,12 @@ mod tests {
         assert!(base.join("bin/rustfmt").exists());
         assert!(base.join("bin/cargo-fmt").exists());
         assert!(base.join("bin/cargo-clippy").exists());
+        assert!(base.join("bin/clippy-driver").exists());
         assert!(base.join("bin/rust-analyzer").exists());
+        assert!(base.join("bin/rustdoc").exists());
+        assert!(base.join("bin/rust-gdb").exists());
+        assert!(base.join("bin/rust-gdbgui").exists());
+        assert!(base.join("bin/rust-lldb").exists());
 
         let _ = fs::remove_dir_all(&base);
     }

--- a/src/tools/rust.rs
+++ b/src/tools/rust.rs
@@ -78,10 +78,15 @@ impl Tool for RustTool {
     fn bin_names(&self) -> Vec<&str> {
         vec![
             "rustc",
+            "rustdoc",
+            "rust-gdb",
+            "rust-gdbgui",
+            "rust-lldb",
             "cargo",
             "rustfmt",
             "cargo-fmt",
             "cargo-clippy",
+            "clippy-driver",
             "rust-analyzer",
         ]
     }
@@ -93,10 +98,15 @@ impl Tool for RustTool {
     fn bin_paths(&self) -> Vec<(&str, &str)> {
         vec![
             ("rustc", "rustc/bin"),
+            ("rustdoc", "rustc/bin"),
+            ("rust-gdb", "rustc/bin"),
+            ("rust-gdbgui", "rustc/bin"),
+            ("rust-lldb", "rustc/bin"),
             ("cargo", "cargo/bin"),
             ("rustfmt", "rustfmt-preview/bin"),
             ("cargo-fmt", "rustfmt-preview/bin"),
             ("cargo-clippy", "clippy-preview/bin"),
+            ("clippy-driver", "clippy-preview/bin"),
             ("rust-analyzer", "rust-analyzer-preview/bin"),
         ]
     }
@@ -181,17 +191,14 @@ mod tests {
 
     #[test]
     fn test_bin_names() {
-        assert_eq!(
-            RustTool.bin_names(),
-            vec![
-                "rustc",
-                "cargo",
-                "rustfmt",
-                "cargo-fmt",
-                "cargo-clippy",
-                "rust-analyzer",
-            ]
-        );
+        let names = RustTool.bin_names();
+        assert_eq!(names.len(), 11);
+        assert!(names.contains(&"rustc"));
+        assert!(names.contains(&"rustdoc"));
+        assert!(names.contains(&"rust-lldb"));
+        assert!(names.contains(&"cargo"));
+        assert!(names.contains(&"clippy-driver"));
+        assert!(names.contains(&"rust-analyzer"));
     }
 
     #[test]
@@ -202,17 +209,13 @@ mod tests {
     #[test]
     fn test_bin_paths_override() {
         let paths = RustTool.bin_paths();
-        assert_eq!(
-            paths,
-            vec![
-                ("rustc", "rustc/bin"),
-                ("cargo", "cargo/bin"),
-                ("rustfmt", "rustfmt-preview/bin"),
-                ("cargo-fmt", "rustfmt-preview/bin"),
-                ("cargo-clippy", "clippy-preview/bin"),
-                ("rust-analyzer", "rust-analyzer-preview/bin"),
-            ]
-        );
+        assert_eq!(paths.len(), 11);
+        assert!(paths.contains(&("rustc", "rustc/bin")));
+        assert!(paths.contains(&("rustdoc", "rustc/bin")));
+        assert!(paths.contains(&("rust-lldb", "rustc/bin")));
+        assert!(paths.contains(&("cargo", "cargo/bin")));
+        assert!(paths.contains(&("clippy-driver", "clippy-preview/bin")));
+        assert!(paths.contains(&("rust-analyzer", "rust-analyzer-preview/bin")));
     }
 
     #[test]


### PR DESCRIPTION
添加 Rust 工具链中遗漏的 5 个二进制文件：

- `rustdoc` (rustc/bin) — 文档生成器
- `clippy-driver` (clippy-preview/bin) — clippy 编译器驱动
- `rust-gdb` (rustc/bin) — GDB 调试包装器
- `rust-gdbgui` (rustc/bin) — GDB GUI 调试器
- `rust-lldb` (rustc/bin) — LLDB 调试包装器（macOS 默认）

同步更新了 bin_names()、bin_paths() 及相关测试。