### PR TITLE
chore: prepare v0.1.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4] - 2026-03-01
+
+### Fixed
+
+- **Uninstall symlink cleanup** — `vex uninstall` now removes stale `current/` and `bin/` symlinks when uninstalling the active version, preventing dangling links
+- **Go verify hint** — `vex use go@x` now prints `go version` instead of incorrect `go --version`
+- **Rust complete toolchain** — Rust installation now includes all components (rustc, rustdoc, cargo, rustfmt, cargo-fmt, cargo-clippy, clippy-driver, rust-analyzer, rust-gdb, rust-gdbgui, rust-lldb) with proper `post_install` hook that links rust-std to sysroot and shared libraries for clippy/rustfmt/rust-analyzer
+- **Java complete binaries** — Expanded Java `bin_names()` from 3 to all 30 JDK executables shipped by Eclipse Temurin
+- **Rust missing binaries** — Added rustdoc, clippy-driver, rust-gdb, rust-gdbgui, rust-lldb to Rust `bin_names()` and `bin_paths()`
+
+### Added
+
+- **`post_install` hook** — Tool trait now supports a `post_install()` method for tool-specific setup after extraction (used by Rust for sysroot and library linking)
+
 ## [0.1.3] - 2026-03-01
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vex"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "MIT"
 authors = ["Noah Qin"]

--- a/README.md
+++ b/README.md
@@ -174,10 +174,10 @@ vex install
 
 | Tool | Binaries | Source |
 |------|----------|--------|
-| Node.js | node, npm, npx | Official binaries |
+| Node.js | node, npm, npx, corepack | Official binaries |
 | Go | go, gofmt | Official binaries |
-| Java | java, javac, jar | Eclipse Temurin JDK |
-| Rust | rustc, cargo | Official stable binaries |
+| Java | java, javac, jar + 27 more JDK tools | Eclipse Temurin JDK |
+| Rust | rustc, rustdoc, cargo, rustfmt, clippy, rust-analyzer + 5 more | Official stable binaries |
 
 ## Fuzzy Version Matching
 
@@ -287,7 +287,7 @@ macOS only for now.
 
 # 2. Remove vex data and binary
 rm -rf ~/.vex
-rm -f ~/.cargo/bin/vex
+rm -f ~/.local/bin/vex
 ```
 
 ## Development


### PR DESCRIPTION
- bump version to 0.1.4
- update CHANGELOG with PR #13/#14/#15 changes
- update README Supported Tools table (complete binary lists)
- fix README uninstall path (~/.cargo/bin → ~/.local/bin)