### PR TITLE
feat: add colorful terminal output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,6 +997,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1856,7 +1862,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vex"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "clap",
  "dialoguer",
@@ -1864,6 +1870,7 @@ dependencies = [
  "flate2",
  "fs2",
  "indicatif",
+ "owo-colors",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,9 @@ dialoguer = "0.12"
 # 文件锁
 fs2 = "0.4"
 
+# 终端颜色
+owo-colors = "4"
+
 # The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use clap::{Parser, Subcommand};
 use dialoguer::{theme::ColorfulTheme, Select};
 use indicatif::{ProgressBar, ProgressStyle};
+use owo_colors::OwoColorize;
 use std::fs;
 use std::path::PathBuf;
 
@@ -125,9 +126,16 @@ fn init_vex() -> Result<()> {
         fs::write(&config_path, "# vex configuration\n")?;
     }
 
-    println!("✓ Created directory structure at {}", vex_dir.display());
+    println!(
+        "{} Created directory structure at {}",
+        "✓".green(),
+        vex_dir.display().to_string().dimmed()
+    );
     println!();
-    println!("Run this to activate vex (auto-switching on cd):");
+    println!(
+        "{}",
+        "Run this to activate vex (auto-switching on cd):".dimmed()
+    );
     println!();
     println!("  echo 'eval \"$(vex env zsh)\"' >> ~/.zshrc && source ~/.zshrc");
     println!();
@@ -210,9 +218,9 @@ fn show_current() -> Result<()> {
     let current_dir = vex_dir.join("current");
 
     if !current_dir.exists() {
-        println!("No tools activated yet.");
+        println!("{}", "No tools activated yet.".dimmed());
         println!();
-        println!("Use 'vex install <tool>' to install a tool.");
+        println!("{}", "Use 'vex install <tool>' to install a tool.".dimmed());
         return Ok(());
     }
 
@@ -231,20 +239,20 @@ fn show_current() -> Result<()> {
     }
 
     if tools.is_empty() {
-        println!("No tools activated yet.");
+        println!("{}", "No tools activated yet.".dimmed());
         println!();
-        println!("Use 'vex install <tool>' to install a tool.");
+        println!("{}", "Use 'vex install <tool>' to install a tool.".dimmed());
         return Ok(());
     }
 
     tools.sort_by(|a, b| a.0.cmp(&b.0));
 
     println!();
-    println!("Current active versions:");
+    println!("{}", "Current active versions:".bold());
     println!();
 
     for (tool, version) in tools {
-        println!("  {} → {}", tool, version);
+        println!("  {} → {}", tool.yellow(), version.cyan());
     }
 
     println!();
@@ -292,7 +300,12 @@ fn uninstall(tool_name: &str, version: &str) -> Result<()> {
         }
     }
 
-    println!("✓ Uninstalled {} {}", tool_name, version);
+    println!(
+        "{} Uninstalled {} {}",
+        "✓".green(),
+        tool_name.yellow(),
+        version.yellow()
+    );
 
     Ok(())
 }
@@ -431,7 +444,12 @@ fn list_remote(tool_name: &str, show_all: bool, use_cache: bool) -> Result<()> {
             .unwrap_or(selected_version);
         let resolved = tools::resolve_fuzzy_version(tool.as_ref(), version)?;
         println!();
-        println!("Installing {}@{}...", tool_name, resolved);
+        println!(
+            "{} {}@{}...",
+            "Installing".cyan(),
+            tool_name.yellow(),
+            resolved.yellow()
+        );
         installer::install(tool.as_ref(), &resolved)?;
         switcher::switch_version(tool.as_ref(), &resolved)?;
     }

--- a/src/switcher.rs
+++ b/src/switcher.rs
@@ -1,5 +1,6 @@
 use crate::error::{Result, VexError};
 use crate::tools::Tool;
+use owo_colors::OwoColorize;
 use std::fs;
 use std::os::unix::fs as unix_fs;
 use std::path::{Path, PathBuf};
@@ -22,7 +23,12 @@ fn switch_version_in(tool: &dyn Tool, version: &str, base_dir: &Path) -> Result<
         });
     }
 
-    println!("Switching {} to version {}...", tool.name(), version);
+    println!(
+        "{} {} to version {}...",
+        "Switching".cyan(),
+        tool.name().yellow(),
+        version.yellow()
+    );
 
     // 1. 更新 current/ 符号链接
     let current_dir = base_dir.join("current");
@@ -47,14 +53,28 @@ fn switch_version_in(tool: &dyn Tool, version: &str, base_dir: &Path) -> Result<
         unix_fs::symlink(&target, &bin_link)?;
     }
 
-    println!("✓ Switched {} to version {}", tool.name(), version);
+    println!(
+        "{} Switched {} to version {}",
+        "✓".green(),
+        tool.name().yellow(),
+        version.yellow()
+    );
     println!();
     let verify_flag = if tool.name() == "go" {
         "version"
     } else {
         "--version"
     };
-    println!("Verify with: {} {}", tool.bin_names()[0], verify_flag);
+    println!(
+        "{} {}",
+        "Verify with:".dimmed(),
+        format!("{} {}", tool.bin_names()[0], verify_flag).cyan()
+    );
+    println!(
+        "{} {}",
+        "Note:".dimmed(),
+        "If 'which' shows old paths, run: hash -r".dimmed()
+    );
 
     Ok(())
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,4 +1,5 @@
 use crate::error::Result;
+use owo_colors::OwoColorize;
 
 pub mod go;
 pub mod java;
@@ -92,7 +93,10 @@ pub fn resolve_fuzzy_version(tool: &dyn Tool, partial: &str) -> Result<String> {
     }
 
     // Partial version — query remote and prefix-match
-    println!("Resolving {}@{}...", tool.name(), partial);
+    println!(
+        "{}...",
+        format!("Resolving {}@{}", tool.name(), partial).cyan()
+    );
     let versions = tool.list_remote()?;
     let prefix = format!("{}.", normalized);
 


### PR DESCRIPTION
为终端输出添加颜色，提升用户体验。

## 改进内容

### 颜色方案
- 🟢 **成功消息**（绿色）：`✓ Installed`, `✓ Switched`, `✓ Checksum verified`
- 🔵 **操作消息**（青色）：`Installing...`, `Downloading...`, `Switching...`
- 🟡 **关键信息**（黄色）：工具名、版本号
- ⚪ **次要信息**（暗淡）：路径、提示文本

### 新增功能
- 在 `vex use` 输出中添加 `hash -r` 提示，解决 shell 命令缓存问题
- 使用 `owo-colors` crate（轻量、现代、自动检测 TTY）

### 示例效果
```
Installing node 24.14.0...
Downloading from https://...
✓ Checksum verified
Extracting...
✓ Installed node 24.14.0 to ~/.vex/toolchains/node/24.14.0
Switching node to version 24.14.0...
✓ Switched node to version 24.14.0

Verify with: node --version
Note: If 'which' shows old paths, run: hash -r
```

## 测试
- ✅ 所有 121 个测试通过
- ✅ 颜色自动适配终端（TTY 检测）
- ✅ 保持克制，避免过度使用颜色