### PR TITLE
chore: prepare v0.1.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5] - 2026-03-01
+
+### Added
+
+- **Colorful terminal output** — Enhanced user experience with color-coded messages:
+  - Green for success messages (✓ Installed, ✓ Switched, ✓ Checksum verified)
+  - Cyan for action messages (Installing, Downloading, Switching)
+  - Yellow for tool names and versions
+  - Dimmed for paths and hints
+- **Shell cache hint** — `vex use` now displays a note about running `hash -r` if `which` shows old paths, addressing shell command cache issues
+
+### Changed
+
+- Improved visual hierarchy in terminal output with moderate color usage
+- Added `owo-colors` dependency for terminal styling (auto-detects TTY)
+
 ## [0.1.4] - 2026-03-01
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vex"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "MIT"
 authors = ["Noah Qin"]


### PR DESCRIPTION
- Bump version to 0.1.5
- Update CHANGELOG with colorful output feature