### PR TITLE
ci: enhance CI/CD with code coverage and improved dependency management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,36 @@ updates:
     directory: /
     schedule:
       interval: weekly
+      day: monday
+      time: "09:00"
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - rust
     commit-message:
-      prefix: "deps"
+      prefix: "chore"
+      include: "scope"
+    reviewers:
+      - imnotnoahhh
+    assignees:
+      - imnotnoahhh
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+      day: monday
+      time: "09:00"
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
     commit-message:
       prefix: "ci"
+      include: "scope"
+    reviewers:
+      - imnotnoahhh
+    assignees:
+      - imnotnoahhh
     ignore:
       # These versions are managed by cargo-dist
       - dependency-name: "actions/download-artifact"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,21 @@ jobs:
       - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  coverage:
+    name: Code Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install tarpaulin
+        run: cargo install cargo-tarpaulin
+      - name: Generate coverage
+        run: cargo tarpaulin --out xml --all-features
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./cobertura.xml
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@
   <a href="https://github.com/imnotnoahhh/vex/actions/workflows/ci.yml">
     <img src="https://img.shields.io/github/actions/workflow/status/imnotnoahhh/vex/ci.yml?style=flat-square&label=CI" alt="CI">
   </a>
+  <a href="https://codecov.io/gh/imnotnoahhh/vex">
+    <img src="https://img.shields.io/codecov/c/github/imnotnoahhh/vex?style=flat-square" alt="Coverage">
+  </a>
   <a href="https://github.com/imnotnoahhh/vex/releases">
     <img src="https://img.shields.io/github/v/release/imnotnoahhh/vex?style=flat-square" alt="Release">
   </a>


### PR DESCRIPTION
## 概述

增强 CI/CD 流程，添加代码覆盖率报告和改进的依赖管理配置。

## 更改内容

### 1. 代码覆盖率集成

新增 coverage job：
- 使用 cargo-tarpaulin 生成覆盖率报告
- 上传到 Codecov 进行可视化
- 生成 XML 格式报告（cobertura.xml）
- 非阻塞模式（fail_ci_if_error: false）

配置要求：
- 需要在 GitHub Secrets 中配置 CODECOV_TOKEN
- 首次运行后可在 Codecov 仪表板查看报告

### 2. Dependabot 配置增强

Cargo 依赖：
- 每周一 09:00 自动检查更新
- 最多同时打开 10 个 PR
- 自动添加 dependencies 和 rust 标签
- 自动分配给 imnotnoahhh 审核
- Commit 前缀：chore

GitHub Actions：
- 每周一 09:00 自动检查更新
- 最多同时打开 5 个 PR
- 自动添加 dependencies 和 github-actions 标签
- 自动分配给 imnotnoahhh 审核
- Commit 前缀：ci
- 忽略 cargo-dist 管理的 actions

### 3. README 更新

添加覆盖率徽章：
- 显示当前代码覆盖率百分比
- 链接到 Codecov 仪表板
- 与其他徽章保持一致的样式

## CI/CD 流程总览

现在的 CI 包含 5 个 job：
1. fmt - 代码格式检查
2. clippy - 代码质量检查
3. test - 单元测试和集成测试
4. audit - 安全漏洞扫描（已存在）
5. coverage - 代码覆盖率报告（新增）

## 配置步骤

合并此 PR 后需要：
1. 在 Codecov.io 注册并关联仓库
2. 获取 CODECOV_TOKEN
3. 在 GitHub Settings > Secrets 中添加 CODECOV_TOKEN
4. 首次运行后覆盖率徽章将自动显示

## 预期效果

- 自动化依赖更新，减少手动维护
- 可视化代码覆盖率，提高代码质量意识
- 更好的 PR 分类和管理
- 持续的安全漏洞监控

## Checklist

- [x] 添加代码覆盖率 job
- [x] 增强 Dependabot 配置
- [x] 更新 README 徽章
- [x] YAML 语法验证通过
- [x] Commit 信息符合规范

## 注意事项

- CODECOV_TOKEN 需要手动配置
- 首次运行 coverage job 可能需要较长时间（安装 tarpaulin）
- Dependabot PR 会自动创建，需要定期审核和合并