### PR TITLE
feat: add vex doctor health check command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -717,7 +717,10 @@ fn run_doctor() -> Result<()> {
         } else {
             println!("{}", "⚠ vex/bin not in PATH".yellow());
             println!("  Add this to your shell config:");
-            println!("  {}", "export PATH=\"$HOME/.vex/bin:$PATH\"".to_string().cyan());
+            println!(
+                "  {}",
+                "export PATH=\"$HOME/.vex/bin:$PATH\"".to_string().cyan()
+            );
             warnings += 1;
         }
     } else {
@@ -812,7 +815,8 @@ fn run_doctor() -> Result<()> {
             for entry in entries.filter_map(|e| e.ok()) {
                 if let Ok(target) = fs::read_link(entry.path()) {
                     if !target.exists() {
-                        broken_links.push(format!("current/{}", entry.file_name().to_string_lossy()));
+                        broken_links
+                            .push(format!("current/{}", entry.file_name().to_string_lossy()));
                     }
                 }
             }


### PR DESCRIPTION
## 概述

添加 `vex doctor` 命令，提供全面的健康检查功能，帮助用户诊断安装问题。

## 功能

### 8 项健康检查

1. **vex 目录存在性** - 检查 ~/.vex 是否存在
2. **目录结构完整性** - 验证 cache、locks、toolchains、current、bin 目录
3. **PATH 配置** - 检查 ~/.vex/bin 是否在 PATH 中
4. **Shell Hook 配置** - 检查 .zshrc/.bashrc 中是否配置了自动切换
5. **已安装工具** - 统计已安装的工具数量
6. **符号链接完整性** - 检测损坏的符号链接
7. **二进制可执行性** - 验证 bin 目录中的文件是否可执行
8. **网络连接** - 测试是否能访问 nodejs.org

### 输出格式

- ✓ 绿色 - 检查通过
- ⚠ 黄色 - 警告（附带修复建议）
- ✗ 红色 - 严重问题
- 最后显示问题和警告的总数

## 使用示例

```bash
$ vex doctor

vex doctor - Health Check

Checking vex directory... ✓
Checking directory structure... ✓
Checking PATH configuration... ⚠ vex/bin not in PATH
  Add this to your shell config:
  export PATH="$HOME/.vex/bin:$PATH"
Checking shell hook... ✓
Checking installed tools... ✓ (4 tools)
Checking symlinks integrity... ✓
Checking binary executability... ✓
Checking network connectivity... ✓

⚠ 1 warning(s)
```

## 使用场景

- 首次安装后验证配置
- 排查 vex 不工作的问题
- 检测损坏的安装
- 验证环境配置

## 测试

所有现有测试通过：121 个测试
Clippy：零警告

## Checklist

- [x] 实现 8 项健康检查
- [x] 提供可操作的修复建议
- [x] 友好的彩色输出
- [x] 代码通过 cargo test
- [x] 代码通过 cargo clippy
- [x] Commit 信息符合规范