### PR TITLE
feat: add fish and nushell shell support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1862,7 +1862,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vex"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "clap",
  "dialoguer",

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -155,10 +155,26 @@ fn test_env_bash() {
 
 #[test]
 fn test_env_unsupported_shell() {
-    let output = vex_bin().args(["env", "fish"]).output().unwrap();
+    let output = vex_bin().args(["env", "powershell"]).output().unwrap();
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("Unsupported shell"));
+}
+
+#[test]
+fn test_env_fish() {
+    let output = vex_bin().args(["env", "fish"]).output().unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("function __vex_use_if_found"));
+}
+
+#[test]
+fn test_env_nushell() {
+    let output = vex_bin().args(["env", "nu"]).output().unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("def --env __vex_use_if_found"));
 }
 
 // --- use --auto 测试 ---


### PR DESCRIPTION
## 概述

添加 fish 和 nushell 的 shell 集成支持，扩展 vex 的 shell 兼容性。

## 新增功能

### Fish Shell 支持

使用 fish 原生语法：
- `on-variable PWD` 监听目录变化
- `function` 定义函数
- `set -gx PATH` 配置环境变量

### Nushell 支持

使用 nushell 原生语法：
- `pre_prompt` hooks 实现自动切换
- `def --env` 定义环境函数
- `$env.PATH` 配置路径

## 使用方法

### Fish
```bash
echo 'vex env fish | source' >> ~/.config/fish/config.fish
source ~/.config/fish/config.fish
```

### Nushell
```bash
vex env nu >> ~/.config/nushell/config.nu
```

## 支持的 Shell

现在支持 4 种 shell：
- ✅ zsh
- ✅ bash
- ✅ fish (新增)
- ✅ nu/nushell (新增)

## 实现细节

### Fish
- 使用 `__vex_on_pwd` 函数监听 PWD 变量
- 自动在目录切换时触发
- 向上遍历查找版本文件

### Nushell
- 集成到 `$env.config.hooks.pre_prompt`
- 每次显示提示符前检查
- 使用 nushell 的路径操作函数

## 测试

新增 4 个测试：
- test_generate_fish_hook - 验证 fish hook 生成
- test_generate_nushell_hook - 验证 nushell hook 生成
- test_env_fish - CLI 测试 fish 输出
- test_env_nushell - CLI 测试 nushell 输出

总测试数：126 个全部通过
Clippy：零警告

## Checklist

- [x] 实现 fish shell 支持
- [x] 实现 nushell 支持
- [x] 添加单元测试
- [x] 添加集成测试
- [x] 更新错误信息
- [x] 代码通过 cargo test
- [x] 代码通过 cargo clippy