### PR TITLE
feat: add vex doctor health check command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -719,7 +719,10 @@ fn run_doctor() -> Result<()> {
         } else {
             println!("{}", "⚠ vex/bin not in PATH".yellow());
             println!("  Add this to your shell config:");
-            println!("  {}", "export PATH=\"$HOME/.vex/bin:$PATH\"".to_string().cyan());
+            println!(
+                "  {}",
+                "export PATH=\"$HOME/.vex/bin:$PATH\"".to_string().cyan()
+            );
             warnings += 1;
         }
     } else {
@@ -814,7 +817,8 @@ fn run_doctor() -> Result<()> {
             for entry in entries.filter_map(|e| e.ok()) {
                 if let Ok(target) = fs::read_link(entry.path()) {
                     if !target.exists() {
-                        broken_links.push(format!("current/{}", entry.file_name().to_string_lossy()));
+                        broken_links
+                            .push(format!("current/{}", entry.file_name().to_string_lossy()));
                     }
                 }
             }


### PR DESCRIPTION
Add comprehensive health check command to diagnose common issues and verify vex installation.

## Changes
- Add 'vex doctor' command with 8 diagnostic checks
- Check vex directory structure and permissions
- Verify PATH configuration
- Validate shell integration
- Check for stale lock files
- Verify installed toolchains
- Test network connectivity
- Validate symlink integrity

## Benefits
- Easy troubleshooting for users
- Proactive issue detection
- Clear actionable recommendations
- Improved user experience

## Testing
- Unit tests for all health checks
- Integration tests for doctor command
- Tests for various failure scenarios

Closes #24