### PR TITLE
chore: prepare v0.1.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6] - 2026-03-02
+
+### Added
+
+- **`vex doctor` command** — Health check command that validates:
+  - vex installation and PATH configuration
+  - Shell hook setup (auto-switch on cd)
+  - Installed tool versions and their activation status
+  - Binary symlinks integrity
+  - Provides actionable suggestions for fixing issues
+- **Disk space check** — Installation now checks for at least 500 MB free disk space before downloading, preventing partial installs on full disks
+- **Path traversal protection** — Archive extraction now validates all paths to prevent malicious tar files from writing outside the installation directory
+- **HTTP timeout configuration** — Network requests now have configurable timeouts:
+  - Connection timeout: 30 seconds
+  - Total timeout: 5 minutes (suitable for large downloads like JDK)
+  - Automatic retry on failure (3 attempts with 2-second intervals)
+  - 4xx client errors (e.g., 404) are not retried
+- **Fish and Nushell shell support** — Added shell integration for Fish and Nushell:
+  - `vex env fish` outputs Fish shell hook
+  - `vex env nu` outputs Nushell hook
+  - Auto-switch on directory change works in all supported shells
+- **Enhanced error messages** — All error types now include actionable troubleshooting suggestions:
+  - Network errors suggest checking internet connection and firewall
+  - Disk space errors show required vs available space
+  - Permission errors provide chmod/chown commands
+  - Version not found errors suggest using `vex list-remote`
+- **Performance benchmarks** — Added criterion-based benchmarks for:
+  - Version file parsing (.tool-versions)
+  - Directory traversal for version resolution
+  - Symlink creation and updates (version switching)
+  - Cache read/write operations
+  - Run with `cargo bench` (not executed in CI)
+- **Comprehensive Rustdoc documentation** — All 14 modules now have detailed Chinese documentation:
+  - Module-level docs explaining purpose and architecture
+  - Function docs with parameters, returns, and errors
+  - Type docs for structs, enums, and traits
+  - Examples and usage notes
+- **End-to-end integration tests** — Added 11 comprehensive E2E tests covering:
+  - Full workflow: install → activate → uninstall
+  - Node.js and Go installation flows
+  - Version switching between multiple installed versions
+  - Version alias resolution (lts, latest)
+  - .tool-versions file parsing and auto-activation
+  - local/global command functionality
+  - Concurrent installation protection
+  - Network-dependent tests marked with `#[ignore]` for CI performance
+
+### Changed
+
+- **64KB buffer size** — Download and checksum calculation now use 64KB buffers for improved performance
+- **User-Agent header** — HTTP requests now identify as `vex/<version>` for better upstream analytics
+- **Home directory error handling** — Replaced `home_dir().unwrap()` with proper error handling using `VexError::HomeDirectoryNotFound`
+
+### Fixed
+
+- **Network-dependent tests** — Marked Java alias resolution test as `#[ignore]` to prevent CI failures when network is unavailable
+
 ## [0.1.5] - 2026-03-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2151,7 +2151,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vex"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "clap",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vex"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 license = "MIT"
 authors = ["Noah Qin"]

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@
 - **Remote version cache** — cached for 5 min by default, configurable via `config.toml`
 - **Concurrent install protection** — file-based locking prevents parallel install corruption
 - **Checksum verification** — Node.js uses official SHA256 verification; Go/Java/Rust follow upstream checksum metadata availability
+- **Health check** — `vex doctor` validates installation, PATH, shell hooks, and provides actionable fixes
+- **Disk space check** — prevents installation when less than 500 MB free space available
+- **Security hardening** — path traversal protection for tar extraction, HTTP timeouts with retry logic
+- **Multi-shell support** — zsh, bash, fish, and nushell integration for auto-switching
 - **macOS native** — supports both Apple Silicon and Intel macOS environments
 
 ## Quick Start
@@ -114,9 +118,21 @@ vex --version
 ```bash
 vex init
 
-# Add shell hook to ~/.zshrc (auto-switch on cd)
+# Add shell hook to your shell config (auto-switch on cd)
+# For zsh:
 echo 'eval "$(vex env zsh)"' >> ~/.zshrc
 source ~/.zshrc
+
+# For bash:
+echo 'eval "$(vex env bash)"' >> ~/.bashrc
+source ~/.bashrc
+
+# For fish:
+echo 'vex env fish | source' >> ~/.config/fish/config.fish
+
+# For nushell:
+vex env nu | save -f ~/.config/nushell/vex.nu
+echo 'source ~/.config/nushell/vex.nu' >> ~/.config/nushell/config.nu
 ```
 
 ### Usage
@@ -171,6 +187,7 @@ vex install
 | `vex alias <tool>` | Show available version aliases | `vex alias node` |
 | `vex current` | Show active versions | `vex current` |
 | `vex uninstall <tool@version>` | Uninstall a version | `vex uninstall node@20.11.0` |
+| `vex doctor` | Run health check and diagnostics | `vex doctor` |
 | `vex env <shell>` | Output shell hook script | `vex env zsh` |
 
 ## Supported Tools
@@ -265,6 +282,14 @@ Switching versions just updates symlinks — instant and shell-restart-free.
 ```
 
 ## FAQ
+
+**How do I troubleshoot installation or PATH issues?**
+Run `vex doctor` to perform a comprehensive health check. It validates:
+- vex installation and PATH configuration
+- Shell hook setup (auto-switch on cd)
+- Installed tool versions and activation status
+- Binary symlinks integrity
+- Provides actionable suggestions for fixing issues
 
 **Why does `vex list-remote go` not show every historical Go release?**
 Go remote listings are constrained by upstream API policy and usually focus on active maintenance lines.

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -203,10 +203,20 @@ fn test_init_shows_eval_hint() {
 
 #[test]
 fn test_install_no_args_no_version_file() {
-    let output = vex_bin().arg("install").output().unwrap();
+    let temp_dir = std::env::temp_dir().join("vex_test_install_no_args");
+    let _ = std::fs::remove_dir_all(&temp_dir);
+    std::fs::create_dir_all(&temp_dir).unwrap();
+
+    let output = vex_bin()
+        .arg("install")
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("No version files found"));
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
 }
 
 // --- local / global 测试 ---


### PR DESCRIPTION
## 概述

准备 v0.1.6 版本发布，更新所有文档以反映自 v0.1.5 以来添加的新功能。

## 更新内容

### 版本号
- 将 Cargo.toml 中的版本从 0.1.5 升级到 0.1.6

### CHANGELOG.md
添加 v0.1.6 版本的完整变更日志，包括：

**新增功能：**
- `vex doctor` 健康检查命令
- 安装前磁盘空间检查（至少 500 MB）
- tar 提取的路径遍历保护
- HTTP 超时配置和重试逻辑
- Fish 和 Nushell shell 支持
- 增强的错误消息（包含故障排除建议）
- 性能基准测试（criterion）
- 全面的 Rustdoc 中文文档
- 端到端集成测试

**改进：**
- 64KB 缓冲区提升性能
- User-Agent 标识
- 主目录错误处理

**修复：**
- 网络依赖测试标记为 `#[ignore]`

### README.md
- 在 Features 部分添加新功能
- 在 Commands 表格中添加 `vex doctor`
- 添加多 shell 设置说明（zsh、bash、fish、nushell）
- 在 FAQ 中添加故障排除条目

### 测试修复
- 修复 `test_install_no_args_no_version_file` 使用临时目录

## 测试结果

所有测试通过：
- 28 个 CLI 测试 ✅
- 5 个 E2E 测试（6 个网络测试被忽略）✅

## 功能验证

已验证所有功能正常工作：
- ✅ `vex --version` 显示 0.1.6
- ✅ `vex doctor` 运行健康检查
- ✅ `vex env fish` 输出 Fish shell 钩子
- ✅ `vex env nu` 输出 Nushell 钩子
- ✅ 所有测试通过