### PR TITLE
fix: harden Java release metadata fallback

### DIFF
--- a/scripts/test_vex_release_strict.py
+++ b/scripts/test_vex_release_strict.py
@@ -90,6 +90,7 @@ BAD_EXEC_PATTERNS = [
 
 RUST_WRAPPER_BINS = {"rust-gdb", "rust-gdbgui", "rust-lldb"}
 JAVA_STRUCTURAL_BINS = {"jconsole", "jstatd", "rmiregistry"}
+JAVA_FALLBACK_LTS_CANDIDATES = [25, 21, 17, 11, 8]
 
 EXPECTED_TOP_LEVEL_COMMANDS = {
     "init": "Initialize vex directory structure",
@@ -1076,24 +1077,24 @@ def resolve_java(spec: str) -> ToolPlan:
         most_recent_lts_int = int(most_recent_lts)
         if most_recent_lts_int > 0:
             lts = [most_recent_lts_int]
+    arch = "aarch64" if os.uname().machine in {"arm64", "aarch64"} else "x64"
+
     if spec == "latest":
-        resolved = str(available[0])
+        if available:
+            resolved = str(available[0])
+            download_url = resolve_java_download_url(resolved, arch)
+        else:
+            resolved, download_url = resolve_java_fallback_lts(releases, arch)
     elif spec == "lts":
-        if not lts:
-            raise TestFailure(f"Adoptium returned no LTS releases in metadata: {releases}")
-        resolved = str(lts[0])
+        if lts:
+            resolved = str(lts[0])
+            download_url = resolve_java_download_url(resolved, arch)
+        else:
+            resolved, download_url = resolve_java_fallback_lts(releases, arch)
     else:
         resolved = str(int(spec))
+        download_url = resolve_java_download_url(resolved, arch)
 
-    arch = "aarch64" if os.uname().machine in {"arm64", "aarch64"} else "x64"
-    asset_url = (
-        f"https://api.adoptium.net/v3/assets/latest/{resolved}/hotspot"
-        f"?architecture={arch}&image_type=jdk&os=mac&vendor=eclipse"
-    )
-    assets = fetch_json(asset_url)
-    if not isinstance(assets, list) or not assets:
-        raise TestFailure(f"Adoptium returned no macOS JDK asset for Java {resolved}")
-    download_url = assets[0]["binary"]["package"]["link"]
     return ToolPlan(
         name="java",
         display_name="Java",
@@ -1105,6 +1106,30 @@ def resolve_java(spec: str) -> ToolPlan:
         bin_regex=JAVA_BIN_RE,
         meta={"versions": [str(version) for version in available], "lts_versions": [str(version) for version in lts]},
     )
+
+
+def resolve_java_download_url(version: str, arch: str) -> str:
+    asset_url = (
+        f"https://api.adoptium.net/v3/assets/latest/{version}/hotspot"
+        f"?architecture={arch}&image_type=jdk&os=mac&vendor=eclipse"
+    )
+    assets = fetch_json(asset_url)
+    if not isinstance(assets, list) or not assets:
+        raise TestFailure(f"Adoptium returned no macOS JDK asset for Java {version}")
+    return assets[0]["binary"]["package"]["link"]
+
+
+def resolve_java_fallback_lts(releases: Dict[str, object], arch: str) -> Tuple[str, str]:
+    for candidate in JAVA_FALLBACK_LTS_CANDIDATES:
+        try:
+            download_url = resolve_java_download_url(str(candidate), arch)
+            REPORT.warn(
+                "Java metadata was incomplete; falling back to probing known LTS releases"
+            )
+            return str(candidate), download_url
+        except TestFailure:
+            continue
+    raise TestFailure(f"Adoptium returned no LTS releases in metadata: {releases}")
 
 
 def resolve_rust(spec: str) -> ToolPlan:

--- a/src/tools/java.rs
+++ b/src/tools/java.rs
@@ -10,6 +10,7 @@ use serde::Deserialize;
 
 /// Java (Eclipse Temurin JDK) tool
 pub struct JavaTool;
+const FALLBACK_LTS_VERSIONS: &[u32] = &[25, 21, 17, 11, 8];
 
 #[derive(Deserialize, Debug)]
 struct AvailableReleases {
@@ -61,13 +62,14 @@ impl Tool for JavaTool {
         let url = "https://api.adoptium.net/v3/info/available_releases";
         let releases: AvailableReleases =
             http::get_json_in_current_context(url, concat!("vex/", env!("CARGO_PKG_VERSION")))?;
-        let lts_versions = lts_versions(&releases);
+        let lts_versions_list = lts_versions(&releases);
+        let available_versions = available_versions(&releases);
 
         // Get all available versions, mark LTS versions
         let mut versions = Vec::new();
 
-        for version in releases.available_releases {
-            let is_lts = lts_versions.contains(&version);
+        for version in available_versions {
+            let is_lts = lts_versions_list.contains(&version);
             versions.push(Version {
                 version: version.to_string(),
                 lts: if is_lts {
@@ -185,14 +187,37 @@ impl Tool for JavaTool {
             }
             "lts" => {
                 // Return the first LTS version
-                Ok(versions
+                if let Some(version) = versions
                     .iter()
                     .find(|v| v.lts.is_some())
-                    .map(|v| v.version.clone()))
+                    .map(|v| v.version.clone())
+                {
+                    return Ok(Some(version));
+                }
+
+                for candidate in FALLBACK_LTS_VERSIONS {
+                    if self
+                        .download_url(&candidate.to_string(), Arch::detect())
+                        .is_ok()
+                    {
+                        return Ok(Some(candidate.to_string()));
+                    }
+                }
+
+                Ok(None)
             }
             _ => Ok(None),
         }
     }
+}
+
+fn available_versions(releases: &AvailableReleases) -> Vec<u32> {
+    releases
+        .available_releases
+        .iter()
+        .copied()
+        .filter(|version| *version > 0)
+        .collect()
 }
 
 fn lts_versions(releases: &AvailableReleases) -> Vec<u32> {
@@ -274,6 +299,17 @@ mod tests {
         };
 
         assert_eq!(lts_versions(&releases), vec![25, 21]);
+    }
+
+    #[test]
+    fn test_available_versions_ignores_zero_entries() {
+        let releases = AvailableReleases {
+            available_lts_releases: vec![25, 21],
+            available_releases: vec![0, 25, 24, 21],
+            most_recent_lts: Some(25),
+        };
+
+        assert_eq!(available_versions(&releases), vec![25, 24, 21]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- harden Java LTS resolution when Adoptium returns incomplete metadata
- fall back to probing known LTS release assets when the metadata endpoint returns empty arrays or placeholder zero values
- keep strict release validation aligned with the current CLI help surface

## Testing
- cargo test test_lts_versions_falls_back_to_most_recent_lts -- --test-threads=1
- cargo test test_lts_versions_ignores_zero_entries -- --test-threads=1
- cargo test test_available_versions_ignores_zero_entries -- --test-threads=1
- python3 -m py_compile scripts/test_vex_release_strict.py
