### PR TITLE
fix: align strict node relink assertion with exec path

### DIFF
--- a/scripts/test_vex_release_strict.py
+++ b/scripts/test_vex_release_strict.py
@@ -1595,10 +1595,16 @@ def validate_node_relink(plan: ToolPlan) -> None:
         [str(VEX_BIN), "exec", "--", "sh", "-c", f"command -v {relinked_name}"],
         timeout=30,
     ).output.strip()
+    resolved_relink_path = None
+    if relink_resolution:
+        try:
+            resolved_relink_path = Path(relink_resolution).resolve()
+        except OSError:
+            resolved_relink_path = None
     REPORT.expect(
-        relink_resolution == str(relink_link),
-        "relinked node binaries resolve via ~/.vex/bin inside vex exec",
-        f"relinked node binary resolved to {relink_resolution}, expected {relink_link}",
+        resolved_relink_path == relink_target.resolve(),
+        "relinked node binaries resolve to the active node toolchain inside vex exec",
+        f"relinked node binary resolved to {relink_resolution}, expected a path targeting {relink_target}",
     )
 
     relink_run = run_cmd([str(VEX_BIN), "exec", "--", relinked_name], timeout=30)


### PR DESCRIPTION
## Summary
- update the strict macOS node relink assertion to validate the resolved target instead of requiring `command -v` to return `~/.vex/bin`
- keep the relink coverage aligned with the active node toolchain path used by `vex exec`

## Validation
- `python3 -m py_compile scripts/test_vex_release_strict.py`
- manual `vex relink node` + `vex exec -- sh -c 'command -v strict-node-relink-check'` repro confirmed `vex exec` resolves to the active node toolchain path and the relinked binary runs successfully
