### PR TITLE
fix: release v1.6.2 security updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.2] - 2026-05-02
+
+### Security
+
+- **Project env keys are now validated before shell export rendering** — `.vex.toml` `[env]` names must be valid environment variable identifiers, preventing malicious project config keys from injecting shell syntax into `vex env <shell> --exports`.
+- **Dependency advisories resolved in the lockfile** — Updated `rustls-webpki` and advisory-flagged `rand` versions to fixed releases used by the locked dependency graph.
+
 ## [1.6.1] - 2026-04-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3246,7 +3246,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vex"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vex"
-version = "1.6.1"
+version = "1.6.2"
 edition = "2021"
 license = "MIT"
 authors = ["Noah Qin"]

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Automatically downloads the correct prebuilt binary for your macOS architecture 
 curl -fsSL https://raw.githubusercontent.com/imnotnoahhh/vex/main/scripts/install-release.sh | bash
 
 # Specific tag
-curl -fsSL https://raw.githubusercontent.com/imnotnoahhh/vex/main/scripts/install-release.sh | bash -s -- --version v1.6.1
+curl -fsSL https://raw.githubusercontent.com/imnotnoahhh/vex/main/scripts/install-release.sh | bash -s -- --version v1.6.2
 ```
 
 For auditability, review the script before running:

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -31,7 +31,7 @@ This script will:
 #### Install Specific Version
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/imnotnoahhh/vex/main/scripts/install-release.sh | bash -s -- --version v1.6.1
+curl -fsSL https://raw.githubusercontent.com/imnotnoahhh/vex/main/scripts/install-release.sh | bash -s -- --version v1.6.2
 ```
 
 #### Audit the Script First
@@ -151,7 +151,7 @@ After installation, verify vex is working:
 
 ```bash
 vex --version
-# vex 1.6.1
+# vex 1.6.2
 
 which vex
 # /Users/yourname/.local/bin/vex

--- a/src/project.rs
+++ b/src/project.rs
@@ -55,6 +55,7 @@ pub fn load_nearest_project_config(start_dir: &Path) -> Result<Option<LoadedProj
     let content = fs::read_to_string(&path)?;
     let config: ProjectConfig = toml::from_str(&content)
         .map_err(|err| VexError::Config(format!("Failed to parse {}: {}", path.display(), err)))?;
+    validate_project_config(&path, &config)?;
 
     Ok(Some(LoadedProjectConfig {
         root: path
@@ -64,6 +65,31 @@ pub fn load_nearest_project_config(start_dir: &Path) -> Result<Option<LoadedProj
         path,
         config,
     }))
+}
+
+fn validate_project_config(path: &Path, config: &ProjectConfig) -> Result<()> {
+    for key in config.env.keys() {
+        let key = key.trim();
+        if !is_valid_env_key(key) {
+            return Err(VexError::Config(format!(
+                "Invalid environment variable name '{}' in {}. Names must match [A-Za-z_][A-Za-z0-9_]*.",
+                key.escape_debug(),
+                path.display()
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn is_valid_env_key(key: &str) -> bool {
+    let mut chars = key.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+
+    matches!(first, 'A'..='Z' | 'a'..='z' | '_')
+        && chars.all(|ch| matches!(ch, 'A'..='Z' | 'a'..='z' | '0'..='9' | '_'))
 }
 
 #[cfg(test)]

--- a/src/project/tests.rs
+++ b/src/project/tests.rs
@@ -38,6 +38,51 @@ test = "cargo test"
 }
 
 #[test]
+fn test_load_nearest_project_config_rejects_unsafe_env_key() {
+    let temp = TempDir::new().unwrap();
+    let project = temp.path().join("project");
+    fs::create_dir_all(&project).unwrap();
+    fs::write(
+        project.join(".vex.toml"),
+        r#"
+[env]
+"EVIL; touch /tmp/vex-poc; #" = "x"
+"#,
+    )
+    .unwrap();
+
+    let error = load_nearest_project_config(&project).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("Invalid environment variable name"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn test_load_nearest_project_config_accepts_valid_env_keys() {
+    let temp = TempDir::new().unwrap();
+    let project = temp.path().join("project");
+    fs::create_dir_all(&project).unwrap();
+    fs::write(
+        project.join(".vex.toml"),
+        r#"
+[env]
+RUST_LOG = "debug"
+_VEX_TEST = "1"
+VEX_TEST_2 = "ok"
+"#,
+    )
+    .unwrap();
+
+    let loaded = load_nearest_project_config(&project)
+        .unwrap()
+        .expect("project config should load");
+    assert_eq!(loaded.config.env.len(), 3);
+}
+
+#[test]
 fn test_find_nearest_venv() {
     let temp = TempDir::new().unwrap();
     let project = temp.path().join("project");


### PR DESCRIPTION
## Summary
- validate project .vex.toml [env] keys before shell export rendering
- bump package version/docs/changelog to v1.6.2
- keep the lockfile on advisory-fixed dependency versions

## Local validation
- cargo fmt --all --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test test_load_nearest_project_config -- --test-threads=1
- cargo audit --file Cargo.lock
