### PR TITLE
Release v1.7.0 Python base and globals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,17 @@ jobs:
         with:
           key: feature-smoke-macos-14
       - run: cargo build
+      - name: Global CLI inventory smoke
+        run: |
+          target/debug/vex globals --help
+          target/debug/vex globals --json
+          target/debug/vex doctor --json > /tmp/vex-doctor.json
+          python3 - <<'PY'
+          import json
+          payload = json.load(open("/tmp/vex-doctor.json"))
+          assert "global_clis" in payload
+          assert any(check["id"] == "global_cli_inventory" for check in payload["checks"])
+          PY
       - run: bash scripts/test-management-features.sh
       - run: VEX_BIN="$(pwd)/target/debug/vex" bash scripts/test-shell-hooks.sh
       - run: VEX_BIN="$(pwd)/target/debug/vex" bash scripts/test-rust-extensions-live.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Python base environments for global Python CLIs** - Each active Python version now has a managed base virtual environment under `~/.vex/python/base/<version>`. Use `vex python base pip install <package>` for tools such as `kaggle` that should be available outside project virtual environments.
+- **Python base workflow commands** - Added `vex python base`, `vex python base path`, `vex python base pip <args...>`, `vex python base freeze`, and `vex python base sync` for inspecting, installing into, locking, and restoring the active Python base environment.
+
+### Changed
+
+- **Python PATH isolation now matches project intent** - Shell activation exposes the Python base environment when no project `.venv` is active, but hides it inside project `.venv` environments so base-installed CLIs and packages do not leak into project dependency resolution.
+- **Python no longer links dynamic toolchain executables into `~/.vex/bin`** - Python keeps its declared interpreter tools linked, while pip-installed console scripts belong in the managed base environment instead of the immutable interpreter toolchain.
+- **Doctor checks Python base health** - `vex doctor` now reports missing or incomplete Python base environments and warns if a base `bin` path is active inside a project virtual environment.
+
 ## [1.6.2] - 2026-05-02
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Python PATH isolation now matches project intent** - Shell activation exposes the Python base environment when no project `.venv` is active, but hides it inside project `.venv` environments so base-installed CLIs and packages do not leak into project dependency resolution.
 - **Python no longer links dynamic toolchain executables into `~/.vex/bin`** - Python keeps its declared interpreter tools linked, while pip-installed console scripts belong in the managed base environment instead of the immutable interpreter toolchain.
+- **Node project CLIs now take precedence over npm globals** - When Node is active and a nearest `node_modules/.bin` exists, shell hooks, `vex exec`, and `vex run` place it before managed npm globals so project-local tools such as `vite`, `eslint`, and `tsc` win over globally installed versions.
 - **Doctor checks Python base health** - `vex doctor` now reports missing or incomplete Python base environments and warns if a base `bin` path is active inside a project virtual environment.
 
 ## [1.6.2] - 2026-05-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Python base environments for global Python CLIs** - Each active Python version now has a managed base virtual environment under `~/.vex/python/base/<version>`. Use `vex python base pip install <package>` for tools such as `kaggle` that should be available outside project virtual environments.
 - **Python base workflow commands** - Added `vex python base`, `vex python base path`, `vex python base pip <args...>`, `vex python base freeze`, and `vex python base sync` for inspecting, installing into, locking, and restoring the active Python base environment.
+- **Global CLI inventory** - Added `vex globals [tool]` with `--json` and `--verbose` to list managed npm globals, Python base CLIs, Go `GOBIN` tools, Cargo-installed tools, and detected Maven/Gradle CLI or cache state with active-version source hints.
 
 ### Changed
 
 - **Python PATH isolation now matches project intent** - Shell activation exposes the Python base environment when no project `.venv` is active, but hides it inside project `.venv` environments so base-installed CLIs and packages do not leak into project dependency resolution.
 - **Python no longer links dynamic toolchain executables into `~/.vex/bin`** - Python keeps its declared interpreter tools linked, while pip-installed console scripts belong in the managed base environment instead of the immutable interpreter toolchain.
 - **Node project CLIs now take precedence over npm globals** - When Node is active and a nearest `node_modules/.bin` exists, shell hooks, `vex exec`, and `vex run` place it before managed npm globals so project-local tools such as `vite`, `eslint`, and `tsc` win over globally installed versions.
-- **Doctor checks Python base health** - `vex doctor` now reports missing or incomplete Python base environments and warns if a base `bin` path is active inside a project virtual environment.
+- **Doctor checks Python base health and global CLI state** - `vex doctor` now reports missing or incomplete Python base environments, warns if a base `bin` path is active inside a project virtual environment, and displays the same global CLI inventory as `vex globals`.
 
 ## [1.6.2] - 2026-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-05-02
+
 ### Added
 
 - **Python base environments for global Python CLIs** - Each active Python version now has a managed base virtual environment under `~/.vex/python/base/<version>`. Use `vex python base pip install <package>` for tools such as `kaggle` that should be available outside project virtual environments.
@@ -17,8 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Python PATH isolation now matches project intent** - Shell activation exposes the Python base environment when no project `.venv` is active, but hides it inside project `.venv` environments so base-installed CLIs and packages do not leak into project dependency resolution.
 - **Python no longer links dynamic toolchain executables into `~/.vex/bin`** - Python keeps its declared interpreter tools linked, while pip-installed console scripts belong in the managed base environment instead of the immutable interpreter toolchain.
+- **Python remote latest filters prefer stable releases** - `vex list-remote python --filter latest` and `--filter major` now skip feature/prerelease artifacts such as alpha builds when a bugfix or security release is available.
 - **Node project CLIs now take precedence over npm globals** - When Node is active and a nearest `node_modules/.bin` exists, shell hooks, `vex exec`, and `vex run` place it before managed npm globals so project-local tools such as `vite`, `eslint`, and `tsc` win over globally installed versions.
 - **Doctor checks Python base health and global CLI state** - `vex doctor` now reports missing or incomplete Python base environments, warns if a base `bin` path is active inside a project virtual environment, and displays the same global CLI inventory as `vex globals`.
+
+### Fixed
+
+- **Python base inventory hides interpreter aliases** - `vex globals python` no longer reports Python interpreter aliases such as python-build-standalone's `𝜋thon` symlink as user-installed global CLIs.
 
 ## [1.6.2] - 2026-05-02
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3246,7 +3246,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vex"
-version = "1.6.2"
+version = "1.7.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vex"
-version = "1.6.2"
+version = "1.7.0"
 edition = "2021"
 license = "MIT"
 authors = ["Noah Qin"]

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 - **Symlink-based switching** — version changes take effect instantly, no shim overhead
 - **Multi-language** — manage Node.js, Go, Java (Eclipse Temurin), Rust, and Python from one tool
 - **Python base + venv integration** — managed per-version base environments for global Python CLIs, plus `vex python init/freeze/sync` for project `.venv` isolation
+- **Python stable latest behavior** — `vex list-remote python --filter latest` prefers bugfix/security releases over feature or prerelease assets
 - **Shell auto-configuration** — `vex init --shell auto` detects and configures your shell automatically (zsh, bash, fish, nushell)
 - **Project templates** — `vex init --list-templates` and `vex init --template <name>` bootstrap official starters for Node, Go, Java, Rust, and Python
 - **Safe add-only templating** — `vex init --template <name> --add-only` only merges `.tool-versions` and `.gitignore`, then creates missing starter files
@@ -92,7 +93,7 @@ Automatically downloads the correct prebuilt binary for your macOS architecture 
 curl -fsSL https://raw.githubusercontent.com/imnotnoahhh/vex/main/scripts/install-release.sh | bash
 
 # Specific tag
-curl -fsSL https://raw.githubusercontent.com/imnotnoahhh/vex/main/scripts/install-release.sh | bash -s -- --version v1.6.2
+curl -fsSL https://raw.githubusercontent.com/imnotnoahhh/vex/main/scripts/install-release.sh | bash -s -- --version v1.7.0
 ```
 
 For auditability, review the script before running:

--- a/README.md
+++ b/README.md
@@ -51,13 +51,14 @@
 - **Lockfile support** — `vex lock` generates reproducible `.tool-versions.lock` with checksums
 - **Team config sync** — `vex install --from` / `vex sync --from` support local files, `vex-config.toml`, HTTPS team configs, and Git repositories with a safe `[tools]` schema
 - **Managed npm globals** — Shell hooks and `vex exec`/`run` export `NPM_CONFIG_PREFIX=$HOME/.vex/npm/prefix`, keep `~/.vex/npm/prefix/bin` on PATH, and prefer project `node_modules/.bin` when present
+- **Global CLI inventory** — `vex globals` shows npm globals, Python base CLIs, Go `GOBIN`, Cargo-installed tools, and Maven/Gradle build-tool state with version-source hints
 - **Auto-export env vars** — Automatic `JAVA_HOME`, `GOROOT`, `CARGO_HOME`, captured user-state env vars, Python base CLI paths, and project `.venv` activation in shell hooks
 - **Official Rust extensions** — `vex rust target/component` manages official Rust toolchain extensions such as `rust-src` and iOS std targets
 - **Contained user-state capture** — supported language homes, caches, and user bins default into `~/.vex`
 - **Explicit home repair** — `vex repair migrate-home` previews and applies safe migrations from legacy home-directory paths
 - **One-command upgrade** — `vex upgrade node` installs and switches to the latest version
 - **Managed context upgrades** — `vex outdated` inspects the current project/global/active scope, and `vex upgrade --all` upgrades that whole managed set
-- **Explicit relink for Node globals** — `vex relink node` rebuilds `~/.vex/bin` after npm adds new executables to the active Node toolchain
+- **Explicit relink for Node toolchain bins** — `vex relink node` rebuilds `~/.vex/bin` when executables appear inside the active Node toolchain
 - **Transient execution** — `vex exec -- <command>` runs tools in the resolved vex environment without changing global symlinks
 - **Project task runner** — `.vex.toml` can define project env vars and named commands for `vex run <task>`
 - **Official GitHub Action** — `uses: imnotnoahhh/vex@v1` installs `vex` plus cached toolchains and managed npm globals on macOS GitHub Actions runners
@@ -71,9 +72,9 @@
 - **Parallel extraction** — fast archive extraction using parallel file processing
 - **Security hardening** — TOCTOU protection, ownership validation, path traversal protection, atomic operations
 - **Self-update** — `vex self-update` upgrades vex itself to the latest GitHub release
-- **Health check** — `vex doctor` validates installation, PATH, shell hooks, managed npm/Python global bins, and active manager conflicts with actionable fixes
+- **Health check** — `vex doctor` validates installation, PATH, shell hooks, managed global bins, Maven/Gradle state, and active manager conflicts with actionable fixes
 - **Disk space check** — prevents installation when less than 500 MB free space available
-- **Machine-readable output** — `--json` for `current`, `list`, `list-remote`, and `doctor`
+- **Machine-readable output** — `--json` for `current`, `globals`, `list`, `list-remote`, and `doctor`
 - **Homebrew support** — optional official tap for brew users, while direct install remains the recommended path
 - **Multi-shell support** — zsh, bash, fish, and nushell integration for auto-switching
 - **macOS native** — supports both Apple Silicon and Intel macOS environments
@@ -213,7 +214,7 @@ vex exec -- node -v
 # Run a named task from .vex.toml
 vex run test
 
-# Rebuild Node binary links after npm installs a new global CLI
+# Rebuild Node binary links after toolchain executables change
 vex relink node
 
 # Preview or apply safe home-directory migrations into ~/.vex
@@ -253,7 +254,7 @@ For the full CLI reference, including command groups and option details, see [do
 | `vex install --from <source>` | Install from a version file, `vex-config.toml`, HTTPS URL, or Git repo | `vex install --from git@github.com:company/vex-config.git` |
 | `vex use <tool@version>` | Switch to installed version | `vex use node@22` |
 | `vex use --auto` | Auto-switch from version files | `vex use --auto` |
-| `vex relink node` | Rebuild `~/.vex/bin` from the active Node toolchain after new npm global executables appear | `vex relink node` |
+| `vex relink node` | Rebuild `~/.vex/bin` from the active Node toolchain | `vex relink node` |
 | `vex local <tool@version>` | Pin version in `.tool-versions` | `vex local node@20.11.0` |
 | `vex global <tool@version>` | Pin version in `~/.vex/tool-versions` | `vex global go@1.23` |
 | `vex list <tool>` | List installed versions | `vex list node` |
@@ -284,6 +285,8 @@ For the full CLI reference, including command groups and option details, see [do
 | `vex run <task> [args...]` | Run a named task from `.vex.toml` | `vex run test -- --nocapture` |
 | `vex current` | Show active versions | `vex current` |
 | `vex current --json` | Show active versions as JSON | `vex current --json` |
+| `vex globals` | Show global CLIs and Java build-tool state | `vex globals --verbose` |
+| `vex globals go --json` | Show global CLI inventory for one tool/ecosystem as JSON | `vex globals go --json` |
 | `vex uninstall <tool@version>` | Uninstall a version | `vex uninstall node@20.11.0` |
 | `vex doctor` | Run health check and diagnostics | `vex doctor` |
 | `vex doctor --json` | Run health check and emit JSON | `vex doctor --json` |

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 
 - **Symlink-based switching** — version changes take effect instantly, no shim overhead
 - **Multi-language** — manage Node.js, Go, Java (Eclipse Temurin), Rust, and Python from one tool
-- **Python venv integration** — `vex python init/freeze/sync` for venv and lockfile management; shell hook auto-activates `.venv` on `cd`
+- **Python base + venv integration** — managed per-version base environments for global Python CLIs, plus `vex python init/freeze/sync` for project `.venv` isolation
 - **Shell auto-configuration** — `vex init --shell auto` detects and configures your shell automatically (zsh, bash, fish, nushell)
 - **Project templates** — `vex init --list-templates` and `vex init --template <name>` bootstrap official starters for Node, Go, Java, Rust, and Python
 - **Safe add-only templating** — `vex init --template <name> --add-only` only merges `.tool-versions` and `.gitignore`, then creates missing starter files
@@ -51,7 +51,7 @@
 - **Lockfile support** — `vex lock` generates reproducible `.tool-versions.lock` with checksums
 - **Team config sync** — `vex install --from` / `vex sync --from` support local files, `vex-config.toml`, HTTPS team configs, and Git repositories with a safe `[tools]` schema
 - **Managed npm globals** — Shell hooks and `vex exec`/`run` export `NPM_CONFIG_PREFIX=$HOME/.vex/npm/prefix` and keep `~/.vex/npm/prefix/bin` on PATH for stable `npm install -g` behavior
-- **Auto-export env vars** — Automatic `JAVA_HOME`, `GOROOT`, `CARGO_HOME`, captured user-state env vars, and project `.venv` activation in shell hooks
+- **Auto-export env vars** — Automatic `JAVA_HOME`, `GOROOT`, `CARGO_HOME`, captured user-state env vars, Python base CLI paths, and project `.venv` activation in shell hooks
 - **Official Rust extensions** — `vex rust target/component` manages official Rust toolchain extensions such as `rust-src` and iOS std targets
 - **Contained user-state capture** — supported language homes, caches, and user bins default into `~/.vex`
 - **Explicit home repair** — `vex repair migrate-home` previews and applies safe migrations from legacy home-directory paths
@@ -71,7 +71,7 @@
 - **Parallel extraction** — fast archive extraction using parallel file processing
 - **Security hardening** — TOCTOU protection, ownership validation, path traversal protection, atomic operations
 - **Self-update** — `vex self-update` upgrades vex itself to the latest GitHub release
-- **Health check** — `vex doctor` validates installation, PATH, shell hooks, managed npm global bins, and active manager conflicts with actionable fixes
+- **Health check** — `vex doctor` validates installation, PATH, shell hooks, managed npm/Python global bins, and active manager conflicts with actionable fixes
 - **Disk space check** — prevents installation when less than 500 MB free space available
 - **Machine-readable output** — `--json` for `current`, `list`, `list-remote`, and `doctor`
 - **Homebrew support** — optional official tap for brew users, while direct install remains the recommended path
@@ -293,6 +293,10 @@ For the full CLI reference, including command groups and option details, see [do
 | `vex env <shell>` | Output shell hook script | `vex env zsh` |
 | `vex rust target <subcommand>` | Manage official Rust targets for the active Rust toolchain | `vex rust target add aarch64-apple-ios` |
 | `vex rust component <subcommand>` | Manage official Rust components for the active Rust toolchain | `vex rust component add rust-src` |
+| `vex python base` | Ensure the active Python base environment exists | `vex python base` |
+| `vex python base pip <args>` | Run pip inside the active Python base environment | `vex python base pip install kaggle` |
+| `vex python base freeze` | Lock base Python CLI packages to `requirements.lock` inside the base env | `vex python base freeze` |
+| `vex python base sync` | Restore base Python CLI packages from the base env lockfile | `vex python base sync` |
 | `vex python init` | Create `.venv` in current directory | `vex python init` |
 | `vex python freeze` | Lock environment to `requirements.lock` | `vex python freeze` |
 | `vex python sync` | Restore environment from `requirements.lock` | `vex python sync` |
@@ -545,17 +549,23 @@ vex install python@3.12   # or: python@latest, python@bugfix, python@security
 # 2. Activate it
 vex use python@3.12
 
-# 3. Create a project venv
+# 3. Optional: install global Python CLIs into the managed base env
+#    These are available when no project .venv is active.
+vex python base
+vex python base pip install kaggle
+kaggle --version
+
+# 4. Create a project venv
 #    Uses ~/.vex/bin/python3 (the active vex-managed python), falls back to system python3
 cd my-project
 vex python init      # runs: python3 -m venv .venv
                      # also writes python version to .tool-versions
 
-# 4. Install packages and lock them
+# 5. Install packages and lock them
 pip install requests flask
 vex python freeze    # runs: pip freeze > requirements.lock
 
-# 5. Commit both files
+# 6. Commit both files
 git add .tool-versions requirements.lock
 ```
 
@@ -568,6 +578,13 @@ vex python sync      # auto-creates .venv if missing + pip install -r requiremen
 ```
 
 The shell hook automatically refreshes `PATH`, `VIRTUAL_ENV`, and captured tool env vars when you `cd` into or out of a project — no manual `source .venv/bin/activate` needed.
+
+Python has two managed dependency scopes:
+
+- `~/.vex/python/base/<version>` is the per-version base environment. Use it for user-level Python CLIs such as `kaggle`, `black`, or `pipx` alternatives when no project `.venv` is active.
+- `project/.venv` is the project environment. When the shell hook activates `.venv`, the Python base `bin` directory is intentionally hidden so base packages and CLI scripts do not leak into the project.
+
+If you install a CLI with `vex python base pip install kaggle`, it is available from the shell outside project virtual environments. Inside a project, install project-specific dependencies into `.venv` and lock them with `vex python freeze`.
 
 `requirements.lock` is generated by `pip freeze` and pins all packages including transitive dependencies. Commit it to git for reproducible environments.
 
@@ -624,6 +641,7 @@ Run `vex doctor` to perform a comprehensive health check. It validates:
 - Shell hook setup (auto-switch on cd)
 - Installed tool versions and activation status
 - Binary symlinks integrity
+- Managed Python base environment health and project `.venv` isolation
 - Provides actionable suggestions for fixing issues
 
 **Why does `vex list-remote go` not show every historical Go release?**

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@
 - **Offline mode** — `--offline` flag for cache-only operations, no network required
 - **Lockfile support** — `vex lock` generates reproducible `.tool-versions.lock` with checksums
 - **Team config sync** — `vex install --from` / `vex sync --from` support local files, `vex-config.toml`, HTTPS team configs, and Git repositories with a safe `[tools]` schema
-- **Managed npm globals** — Shell hooks and `vex exec`/`run` export `NPM_CONFIG_PREFIX=$HOME/.vex/npm/prefix` and keep `~/.vex/npm/prefix/bin` on PATH for stable `npm install -g` behavior
+- **Managed npm globals** — Shell hooks and `vex exec`/`run` export `NPM_CONFIG_PREFIX=$HOME/.vex/npm/prefix`, keep `~/.vex/npm/prefix/bin` on PATH, and prefer project `node_modules/.bin` when present
 - **Auto-export env vars** — Automatic `JAVA_HOME`, `GOROOT`, `CARGO_HOME`, captured user-state env vars, Python base CLI paths, and project `.venv` activation in shell hooks
 - **Official Rust extensions** — `vex rust target/component` manages official Rust toolchain extensions such as `rust-src` and iOS std targets
 - **Contained user-state capture** — supported language homes, caches, and user bins default into `~/.vex`
@@ -168,7 +168,7 @@ vex env nu | save -f ~/.config/nushell/vex.nu
 echo 'source ~/.config/nushell/vex.nu' >> ~/.config/nushell/config.nu
 ```
 
-The generated hook keeps `~/.vex/npm/prefix/bin` and `~/.vex/bin` on `PATH`, runs `vex use --auto` on directory changes, and refreshes the exported activation environment via `vex env <shell> --exports`.
+The generated hook keeps `~/.vex/npm/prefix/bin` and `~/.vex/bin` on `PATH`, runs `vex use --auto` on directory changes, and refreshes the exported activation environment via `vex env <shell> --exports`. In Node projects, the refreshed PATH prefers the nearest `node_modules/.bin` before managed npm globals so project-local CLIs win.
 
 ### Usage
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -88,7 +88,8 @@ Recent user-facing additions that should stay in sync across these docs:
 
 - `vex init --template`, `--list-templates`, and `--add-only`
 - managed npm globals in `~/.vex/npm/prefix` plus the `NPM_CONFIG_PREFIX` shell/export behavior
-- `vex relink node` for rebuilding Node global binary links without reinstalling or switching versions
+- `vex globals` for inspecting npm, Python base, Go, Cargo, Maven, and Gradle global CLI/build-tool state
+- `vex relink node` for rebuilding active Node toolchain binary links without reinstalling or switching versions
 - full CLI reference coverage in `command-reference.md`
 - safe remote team config sources via `vex install --from` / `vex sync --from`
 - the macOS-only `imnotnoahhh/vex` GitHub Action and cache behavior

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -116,7 +116,7 @@ Update version in the following files:
 ## [1.6.1] - 2026-04-06
 
 ### Fixed
-- Node managed npm prefix and relink behavior for newly installed global CLIs
+- Node managed npm prefix visibility and global CLI inventory
 
 ### Changed
 - Documentation refresh and CI/cache updates for managed npm globals

--- a/docs/guides/best-practices.md
+++ b/docs/guides/best-practices.md
@@ -211,6 +211,12 @@ CI recommendations:
 - keep version files in the repository so cache keys reflect real tool changes
 - use `vex repair migrate-home` after onboarding to pull supported legacy home state into `~/.vex`
 
+## Node Projects
+
+Install project tools into `node_modules` and commit the package-manager lockfile. When Node is active, `vex` puts the nearest `node_modules/.bin` before managed npm globals in shell hooks, `vex exec`, and `vex run`.
+
+That means direct commands such as `vite`, `eslint`, and `tsc` resolve to the project-installed versions first. Use `npm install -g` for user-level CLIs only; those go into `~/.vex/npm/prefix/bin`.
+
 ## Rust Projects
 
 For Rust projects that need official extensions, keep them in `vex` instead of falling back to a second toolchain manager:

--- a/docs/guides/best-practices.md
+++ b/docs/guides/best-practices.md
@@ -276,6 +276,15 @@ Do not commit:
 
 With the shell hook installed, `vex` auto-activates `.venv` when you enter the project and deactivates it when you leave.
 
+Use the Python base environment for user-level CLI tools that are not project dependencies:
+
+```bash
+vex use python@3.12
+vex python base pip install kaggle
+```
+
+That installs into `~/.vex/python/base/<version>`, not into the interpreter toolchain. When no project `.venv` is active, the shell hook exposes the base `bin` directory so commands such as `kaggle` are available. When a project `.venv` is active, `vex` hides the base `bin` directory so global Python CLIs and packages do not affect project dependency resolution.
+
 ## Keep PATH Ownership Simple
 
 Version managers are easiest to operate when only one of them owns the front of `PATH`.

--- a/docs/guides/best-practices.md
+++ b/docs/guides/best-practices.md
@@ -217,6 +217,14 @@ Install project tools into `node_modules` and commit the package-manager lockfil
 
 That means direct commands such as `vite`, `eslint`, and `tsc` resolve to the project-installed versions first. Use `npm install -g` for user-level CLIs only; those go into `~/.vex/npm/prefix/bin`.
 
+Use `vex globals --verbose` when debugging command resolution. It shows the global CLI path, source kind, and active version source for npm, Python base, Go, Cargo, Maven, and Gradle entries.
+
+## Java Build Tools
+
+`vex` manages the active JDK and `JAVA_HOME`; Maven and Gradle remain project or system tools. Prefer `mvnw` and `gradlew` inside projects so the build tool version is pinned with the repository.
+
+`vex globals java` and `vex doctor` report external `mvn`/`gradle` binaries plus `~/.m2` and `~/.gradle` state so you can see when Java build-tool state lives outside `~/.vex`.
+
 ## Rust Projects
 
 For Rust projects that need official extensions, keep them in `vex` instead of falling back to a second toolchain manager:

--- a/docs/guides/command-reference.md
+++ b/docs/guides/command-reference.md
@@ -258,8 +258,9 @@ vex relink <tool>
 Notes:
 
 - currently only `node` is supported
-- use this after `npm install -g <package>` adds a new executable to the active Node toolchain
+- use this after `npm install -g <package>` adds a new executable to the managed npm prefix
 - it only rebuilds links under `~/.vex/bin`; it does not install packages or change shell configuration
+- project-local `node_modules/.bin` is preferred automatically when Node is active, so local CLIs win over npm globals in shell hooks, `vex exec`, and `vex run`
 
 Examples:
 

--- a/docs/guides/command-reference.md
+++ b/docs/guides/command-reference.md
@@ -610,10 +610,27 @@ Supported values:
   - run `pip freeze` and write `requirements.lock`
 - `sync`
   - create `.venv` if needed and restore dependencies from `requirements.lock`
+- `base`
+  - manage the active Python base environment for user-level Python CLIs
+
+`vex python base` accepts these nested forms:
+
+- `vex python base`
+  - create the active version's base environment if needed
+- `vex python base path`
+  - print the active version's base environment path
+- `vex python base pip <args...>`
+  - run `pip` inside the active version's base environment
+- `vex python base freeze`
+  - write the base environment package set to `~/.vex/python/base/<version>/requirements.lock`
+- `vex python base sync`
+  - restore the base environment from that lockfile
 
 Usage:
 
 ```bash
+vex python base
+vex python base pip install kaggle
 vex python init
 vex python freeze
 vex python sync
@@ -623,12 +640,17 @@ Recommended workflow:
 
 ```bash
 vex install python@3.12
+vex use python@3.12
+vex python base pip install kaggle
+
 cd my-project
 vex python init
 pip install requests flask
 vex python freeze
 vex python sync
 ```
+
+The Python base environment is for global CLI tools. Project `.venv` environments stay separate: when the shell hook activates `.venv`, the base environment's `bin` directory is hidden from `PATH` so base-installed tools and packages do not leak into the project.
 
 ## Interactive and Self-Management Commands
 

--- a/docs/guides/command-reference.md
+++ b/docs/guides/command-reference.md
@@ -144,6 +144,7 @@ vex globals
 vex globals --verbose
 vex globals go --json
 vex globals maven
+vex globals mvn
 vex globals gradle
 ```
 
@@ -157,6 +158,8 @@ The inventory includes:
 - Maven and Gradle build-tool state under `~/.m2` and `~/.gradle`
 
 Each entry includes its path, source kind, and the active vex version source when a matching toolchain is active.
+
+Supported filters are `all`, `node`, `python`, `go`, `rust`, `java`, `maven`, `mvn`, and `gradle`.
 
 ### `vex repair`
 
@@ -424,6 +427,8 @@ Options:
   - use only cached remote data
 - `--json`
   - print machine-readable output
+
+For Python, the `latest` and `major` filters prefer bugfix/security releases over feature or prerelease assets when both are present.
 
 Examples:
 

--- a/docs/guides/command-reference.md
+++ b/docs/guides/command-reference.md
@@ -25,6 +25,7 @@ vex relink
 vex list
 vex list-remote
 vex current
+vex globals
 vex uninstall
 vex env
 vex local
@@ -115,7 +116,7 @@ Notes:
 
 Run health checks for the current installation.
 
-The report includes core PATH/symlink checks, managed npm global bin checks, and active PATH conflicts from other tool managers that can shadow vex.
+The report includes core PATH/symlink checks, managed global CLI inventory, Maven/Gradle state, and active PATH conflicts from other tool managers that can shadow vex.
 
 Usage:
 
@@ -131,6 +132,31 @@ Options:
   - print machine-readable diagnostics
 - `--verbose`
   - include extra provenance and captured-environment details in text output
+
+### `vex globals`
+
+List global CLIs and build-tool state that can affect command resolution.
+
+Usage:
+
+```bash
+vex globals
+vex globals --verbose
+vex globals go --json
+vex globals maven
+vex globals gradle
+```
+
+The inventory includes:
+
+- npm globals from `~/.vex/npm/prefix/bin`
+- Python base CLIs from `~/.vex/python/base/<version>/bin`
+- Go tools from `~/.vex/go/bin`
+- Cargo-installed tools from `~/.vex/cargo/bin`
+- external `mvn` and `gradle` CLIs found on PATH
+- Maven and Gradle build-tool state under `~/.m2` and `~/.gradle`
+
+Each entry includes its path, source kind, and the active vex version source when a matching toolchain is active.
 
 ### `vex repair`
 
@@ -258,7 +284,8 @@ vex relink <tool>
 Notes:
 
 - currently only `node` is supported
-- use this after `npm install -g <package>` adds a new executable to the managed npm prefix
+- use this only when an executable appears inside the active Node toolchain's `bin`
+- npm globals installed into `~/.vex/npm/prefix/bin` are already on PATH and do not need relinking
 - it only rebuilds links under `~/.vex/bin`; it does not install packages or change shell configuration
 - project-local `node_modules/.bin` is preferred automatically when Node is active, so local CLIs win over npm globals in shell hooks, `vex exec`, and `vex run`
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -219,7 +219,19 @@ vex install python@3.12   # or: python@latest, python@stable
 vex global python@3.12    # set as global default
 ```
 
-### Step 2 — Set up a project
+### Step 2 — Install optional global Python CLIs
+
+Global Python CLIs live in the active version's base environment, similar to a small `conda base` for user tools:
+
+```bash
+vex use python@3.12
+vex python base pip install kaggle
+kaggle --version
+```
+
+When no project `.venv` is active, the shell hook exposes `~/.vex/python/base/<version>/bin`. When a project `.venv` is active, that base `bin` path is hidden so base packages do not leak into the project.
+
+### Step 3 — Set up a project
 
 ```bash
 cd my-project
@@ -228,7 +240,7 @@ vex python init
 
 This creates `.venv` in the current directory using the active vex-managed Python, and records the version in `.tool-versions`.
 
-### Step 3 — Install packages and lock them
+### Step 4 — Install packages and lock them
 
 ```bash
 source .venv/bin/activate   # or let the shell hook do it automatically on next cd
@@ -236,14 +248,14 @@ pip install requests flask
 vex python freeze            # writes requirements.lock
 ```
 
-### Step 4 — Commit
+### Step 5 — Commit
 
 ```bash
 git add .tool-versions requirements.lock
 git commit -m "pin python and dependencies"
 ```
 
-### Step 5 — Restore on another machine
+### Step 6 — Restore on another machine
 
 ```bash
 vex install python@3.12

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -195,6 +195,8 @@ vex exec -- node -v
 vex exec -- python -m pytest
 ```
 
+When Node is active, `vex` also prefers the nearest `node_modules/.bin` before managed npm globals. That keeps commands such as `vite`, `eslint`, and `tsc` pointed at the project-installed version when you run them directly, through `vex exec`, or through `vex run`.
+
 Use `.vex.toml` plus `vex run` for repeatable project tasks:
 
 ```toml

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -197,6 +197,15 @@ vex exec -- python -m pytest
 
 When Node is active, `vex` also prefers the nearest `node_modules/.bin` before managed npm globals. That keeps commands such as `vite`, `eslint`, and `tsc` pointed at the project-installed version when you run them directly, through `vex exec`, or through `vex run`.
 
+Use `vex globals` when a command resolves differently than expected:
+
+```bash
+vex globals --verbose
+vex globals go --json
+```
+
+It lists managed global CLIs from npm, Python base environments, Go, and Cargo, plus Maven/Gradle CLI and cache state with active version-source hints.
+
 Use `.vex.toml` plus `vex run` for repeatable project tasks:
 
 ```toml

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -31,7 +31,7 @@ This script will:
 #### Install Specific Version
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/imnotnoahhh/vex/main/scripts/install-release.sh | bash -s -- --version v1.6.2
+curl -fsSL https://raw.githubusercontent.com/imnotnoahhh/vex/main/scripts/install-release.sh | bash -s -- --version v1.7.0
 ```
 
 #### Audit the Script First
@@ -151,7 +151,7 @@ After installation, verify vex is working:
 
 ```bash
 vex --version
-# vex 1.6.2
+# vex 1.7.0
 
 which vex
 # /Users/yourname/.local/bin/vex

--- a/docs/guides/migration-comparison.md
+++ b/docs/guides/migration-comparison.md
@@ -211,7 +211,7 @@ According to the official `pyenv` docs, `pyenv` uses shims, resolves versions fr
 
 - `.python-version` can stay in place temporarily because `vex` reads it.
 - `pyenv local` maps conceptually to a project version file.
-- `pyenv global` maps conceptually to `vex global python@<version>`.
+- `pyenv global` maps conceptually to `vex global python@<version>`; user-level Python CLIs belong in `vex python base`.
 - `pyenv-virtualenv` style "activate a project environment when I enter the directory" maps conceptually to `vex` shell hook plus a local `.venv`.
 
 ### What changes
@@ -219,10 +219,15 @@ According to the official `pyenv` docs, `pyenv` uses shims, resolves versions fr
 - `vex` stores global defaults in `~/.vex/tool-versions`, not in `pyenv`'s global file location.
 - `vex` does not expose a direct equivalent of `pyenv shell` or `PYENV_VERSION`.
 - For one-off commands, `vex exec` is the cleaner replacement.
+- For global Python CLIs installed with pip, use the per-version base environment:
+  - `vex python base pip install kaggle`
+  - `vex python base freeze`
+  - `vex python base sync`
 - For Python environments, `vex` uses project-local `.venv` plus:
   - `vex python init`
   - `vex python freeze`
   - `vex python sync`
+- The base environment is hidden while a project `.venv` is active, so base-installed tools do not leak into project dependency resolution.
 - If your `.python-version` file contains multiple entries or other `pyenv`-specific patterns, rewrite it to a single version string before treating it as a `vex` source of truth.
 
 ### Suggested migration flow
@@ -236,14 +241,21 @@ According to the official `pyenv` docs, `pyenv` uses shims, resolves versions fr
 
 2. For Python-only repos, you can keep `.python-version` during the initial migration.
 
-3. For mixed-language repos, convert to `.tool-versions`:
+3. Move global pip CLIs into the active Python base environment:
+
+   ```bash
+   vex python base pip install kaggle
+   vex python base freeze
+   ```
+
+4. For mixed-language repos, convert to `.tool-versions`:
 
    ```text
    python 3.12.8
    node 20.11.0
    ```
 
-4. Replace virtualenv plugin workflows with `vex` commands:
+5. Replace virtualenv plugin workflows with `vex` commands:
 
    ```bash
    vex python init
@@ -251,7 +263,7 @@ According to the official `pyenv` docs, `pyenv` uses shims, resolves versions fr
    vex python sync
    ```
 
-5. Verify:
+6. Verify:
 
    ```bash
    vex current

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -213,7 +213,7 @@ find ~/.vex -type l ! -exec test -e {} \; -print
    find ~/.vex/current -type l ! -exec test -e {} \; -delete
    ```
 
-2. **If this is a newly installed npm global CLI, rebuild Node links explicitly**:
+2. **If the broken link points into the active Node toolchain, rebuild Node links explicitly**:
    ```bash
    vex relink node
    ```
@@ -238,9 +238,9 @@ vex doctor
 
 **Solutions**:
 
-1. **Rebuild Node links**:
+1. **Inspect the managed global CLI path**:
    ```bash
-   vex relink node
+   vex globals node --verbose
    ```
 
 2. **Refresh shell integration if the managed npm bin path is missing**:
@@ -248,7 +248,12 @@ vex doctor
    vex init --shell auto
    ```
 
-3. **Move competing tool-manager paths behind vex when doctor reports conflicts**:
+3. **Reopen the shell or reload shell hooks after refreshing integration**:
+   ```bash
+   exec $SHELL
+   ```
+
+4. **Move competing tool-manager paths behind vex when doctor reports conflicts**:
    - `vex` will warn about active `pyenv`, `nvm`, `fnm`, `volta`, `asdf`, or cargo env paths only when they appear before `~/.vex/bin`
    - `vex` does not auto-migrate those tools; it only reports that they are actively shadowing managed binaries
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -91,6 +91,7 @@ VEX_STRICT_VEX_BIN="$(pwd)/target/debug/vex"
 - 项目与全局切换：`.tool-versions`、`vex global`、shell hook `cd` 自动切换
 - Python 自动激活：进入项目自动激活 `.venv`，离开项目自动退出，并隐藏 Python base `bin`
 - 健康检查：`vex doctor`
+- 全局 CLI 盘点：`vex globals` 覆盖 Go、Rust、Python、Node 与 Java Maven/Gradle 状态
 - Rust 官方扩展：`vex rust target add/remove`、`vex rust component add/remove`
 - 模板与 team-config 相关 CLI：由单元测试与 CLI integration tests 覆盖
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -86,10 +86,10 @@ VEX_STRICT_VEX_BIN="$(pwd)/target/debug/vex"
 - 官方归档比对：将本地安装结果与官方 macOS 归档中的二进制清单做比对
 - symlink 校验：`~/.vex/current/*` 与 `~/.vex/bin/*`
 - 可执行性校验：按工具特征探测 `--version` / `--help` / `-version` 等
-- Python 工作流：`vex python init / freeze / sync`
+- Python 工作流：`vex python init / freeze / sync`，以及 Python base 环境路径隔离
 - 多版本切换：手动切到备用版本，再切回目标版本
 - 项目与全局切换：`.tool-versions`、`vex global`、shell hook `cd` 自动切换
-- Python 自动激活：进入项目自动激活 `.venv`，离开项目自动退出
+- Python 自动激活：进入项目自动激活 `.venv`，离开项目自动退出，并隐藏 Python base `bin`
 - 健康检查：`vex doctor`
 - Rust 官方扩展：`vex rust target add/remove`、`vex rust component add/remove`
 - 模板与 team-config 相关 CLI：由单元测试与 CLI integration tests 覆盖

--- a/scripts/test-management-features.sh
+++ b/scripts/test-management-features.sh
@@ -23,6 +23,8 @@ LOCAL_HOME="$TMP_ROOT/local-home"
 NETWORK_HOME="$TMP_ROOT/network-home"
 PROJECT_DIR="$TMP_ROOT/project"
 DOCTOR_PROJECT="$TMP_ROOT/doctor-project"
+GLOBALS_HOME="$TMP_ROOT/globals-home"
+GLOBALS_PROJECT="$TMP_ROOT/globals-project"
 
 PASS=0
 FAIL=0
@@ -104,13 +106,20 @@ EOF
     chmod +x "$path"
 }
 
+write_executable_script() {
+    local path="$1"
+    local body="$2"
+    printf '%s\n' "$body" > "$path"
+    chmod +x "$path"
+}
+
 echo ""
 echo "============================================================"
 echo "vex management feature smoke test"
 echo "JSON + outdated + upgrade --all + prune/gc + doctor + .vex.toml + exec/run"
 echo "============================================================"
 
-mkdir -p "$LOCAL_HOME" "$NETWORK_HOME" "$PROJECT_DIR" "$DOCTOR_PROJECT"
+mkdir -p "$LOCAL_HOME" "$NETWORK_HOME" "$PROJECT_DIR" "$DOCTOR_PROJECT" "$GLOBALS_HOME" "$GLOBALS_PROJECT"
 
 run_local init --shell zsh >/dev/null
 
@@ -276,6 +285,53 @@ installed_json="$TMP_ROOT/list-node.json"
 run_local list node --json > "$installed_json"
 require_python_json "$installed_json" "list node --json includes both installed versions" \
     "versions = {entry['version'] for entry in payload['versions']}; assert {'20.20.1', '25.8.0'} <= versions; assert payload['current_version'] == '20.20.1'"
+
+echo ""
+echo "[ global CLI inventory workflows ]"
+
+mkdir -p \
+    "$GLOBALS_HOME/.vex/npm/prefix/bin" \
+    "$GLOBALS_HOME/.vex/go/bin" \
+    "$GLOBALS_HOME/.vex/cargo/bin" \
+    "$GLOBALS_HOME/.vex/toolchains/go/1.25.4" \
+    "$GLOBALS_HOME/.vex/current" \
+    "$GLOBALS_HOME/.m2/repository" \
+    "$GLOBALS_HOME/.gradle/caches" \
+    "$GLOBALS_HOME/.gradle/wrapper" \
+    "$TMP_ROOT/build-tools"
+
+write_executable_script "$GLOBALS_HOME/.vex/npm/prefix/bin/vite" '#!/bin/sh
+echo npm-global-vite'
+write_executable_script "$GLOBALS_HOME/.vex/go/bin/gopls" '#!/bin/sh
+echo gopls'
+write_executable_script "$GLOBALS_HOME/.vex/cargo/bin/cargo-audit" '#!/bin/sh
+echo cargo-audit'
+write_executable_script "$TMP_ROOT/build-tools/mvn" '#!/bin/sh
+echo Apache Maven fake'
+write_executable_script "$TMP_ROOT/build-tools/gradle" '#!/bin/sh
+echo Gradle fake'
+ln -s "$GLOBALS_HOME/.vex/toolchains/go/1.25.4" "$GLOBALS_HOME/.vex/current/go"
+cat > "$GLOBALS_HOME/.vex/tool-versions" <<'EOF'
+go 1.25.4
+EOF
+
+globals_json="$TMP_ROOT/globals.json"
+HOME="$GLOBALS_HOME" PATH="$TMP_ROOT/build-tools:$GLOBALS_HOME/.vex/npm/prefix/bin:$GLOBALS_HOME/.vex/bin:$BASE_PATH" \
+    "$VEX_BIN" globals --json > "$globals_json"
+require_python_json "$globals_json" "globals --json reports npm, Go, Cargo, Maven, and Gradle state" \
+    "entries = payload['entries']; names = {(entry['tool'], entry['name']) for entry in entries}; assert ('node', 'vite') in names; assert ('go', 'gopls') in names; assert ('rust', 'cargo-audit') in names; assert ('java', 'mvn') in names; assert ('java', 'gradle') in names; assert ('java', 'maven-local-repository') in names; assert ('java', 'gradle-caches') in names; gopls = next(entry for entry in entries if entry['tool'] == 'go' and entry['name'] == 'gopls'); assert gopls['tool_version'] == '1.25.4'; assert gopls['version_source'] == 'Global default'"
+
+globals_go_json="$TMP_ROOT/globals-go.json"
+HOME="$GLOBALS_HOME" PATH="$TMP_ROOT/build-tools:$GLOBALS_HOME/.vex/npm/prefix/bin:$GLOBALS_HOME/.vex/bin:$BASE_PATH" \
+    "$VEX_BIN" globals go --json > "$globals_go_json"
+require_python_json "$globals_go_json" "globals go --json filters to Go global CLIs" \
+    "entries = payload['entries']; assert entries and all(entry['tool'] == 'go' for entry in entries); assert any(entry['name'] == 'gopls' for entry in entries)"
+
+globals_doctor_json="$TMP_ROOT/globals-doctor.json"
+HOME="$GLOBALS_HOME" PATH="$TMP_ROOT/build-tools:$GLOBALS_HOME/.vex/npm/prefix/bin:$GLOBALS_HOME/.vex/bin:$BASE_PATH" \
+    "$VEX_BIN" doctor --json > "$globals_doctor_json"
+require_python_json "$globals_doctor_json" "doctor --json includes global CLI inventory details" \
+    "assert payload['global_clis']; check = next(item for item in payload['checks'] if item['id'] == 'global_cli_inventory'); assert check['status'] == 'ok'; details = '\\n'.join(check['details']); assert 'go:' in details and 'node:' in details and 'java:' in details"
 
 exec_output="$TMP_ROOT/exec.txt"
 run_local_in "$PROJECT_DIR" exec -- node > "$exec_output"

--- a/src/activation.rs
+++ b/src/activation.rs
@@ -28,6 +28,7 @@ pub fn build_activation_plan(cwd: &Path) -> Result<ActivationPlan> {
     let versions = resolve_active_versions(cwd, &vex_dir)?;
     let venv_dir = resolve_venv_dir(cwd, project.as_ref())?;
     let shared_path_entries = collect_shared_path_entries(
+        cwd,
         &vex_dir,
         &toolchains_dir,
         &versions,

--- a/src/activation/env.rs
+++ b/src/activation/env.rs
@@ -70,6 +70,10 @@ pub(super) fn collect_shared_path_entries(
 
     if capture_user_state {
         for (tool_name, version) in versions {
+            if tool_name == "python" && venv_dir.is_some() {
+                continue;
+            }
+
             let tool = tools::get_tool(tool_name)?;
             let install_dir = checked_install_dir(toolchains_dir, tool_name, version)?;
             let environment = tool.managed_environment(vex_dir, Some(&install_dir));

--- a/src/activation/env.rs
+++ b/src/activation/env.rs
@@ -55,6 +55,7 @@ pub(super) fn resolve_active_versions(
 }
 
 pub(super) fn collect_shared_path_entries(
+    cwd: &Path,
     vex_dir: &Path,
     toolchains_dir: &Path,
     versions: &BTreeMap<String, String>,
@@ -66,6 +67,12 @@ pub(super) fn collect_shared_path_entries(
 
     if let Some(venv_dir) = venv_dir {
         push_path_entry(&mut path_entries, &mut path_seen, venv_dir.join("bin"));
+    }
+
+    if versions.contains_key("node") {
+        if let Some(node_modules_bin) = project::find_nearest_node_modules_bin(cwd) {
+            push_path_entry(&mut path_entries, &mut path_seen, node_modules_bin);
+        }
     }
 
     if capture_user_state {

--- a/src/activation/tests.rs
+++ b/src/activation/tests.rs
@@ -41,3 +41,67 @@ fn test_activation_plan_uses_project_venv_and_toolchain_bins() {
         std::env::remove_var("HOME");
     }
 }
+
+#[test]
+fn test_activation_plan_uses_python_base_without_project_venv() {
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    let vex_dir = home.path().join(".vex");
+    let toolchain_bin = vex_dir.join("toolchains/python/3.13.3/bin");
+    let base_bin = vex_dir.join("python/base/3.13.3/bin");
+    fs::create_dir_all(&toolchain_bin).unwrap();
+    fs::create_dir_all(&base_bin).unwrap();
+    fs::write(project.path().join(".tool-versions"), "python 3.13.3\n").unwrap();
+
+    let old_home = std::env::var("HOME").ok();
+    std::env::set_var("HOME", home.path());
+    let plan = build_activation_plan(project.path()).unwrap();
+
+    let shell = shell_path(&plan).unwrap();
+    assert!(
+        shell.starts_with(base_bin.to_string_lossy().as_ref()),
+        "shell path was: {shell}"
+    );
+    let exec = exec_path(&plan);
+    assert!(exec.contains(toolchain_bin.to_string_lossy().as_ref()));
+
+    if let Some(value) = old_home {
+        std::env::set_var("HOME", value);
+    } else {
+        std::env::remove_var("HOME");
+    }
+}
+
+#[test]
+fn test_activation_plan_hides_python_base_inside_project_venv() {
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    let vex_dir = home.path().join(".vex");
+    let toolchain_bin = vex_dir.join("toolchains/python/3.13.3/bin");
+    let base_bin = vex_dir.join("python/base/3.13.3/bin");
+    let venv_bin = project.path().join(".venv/bin");
+    fs::create_dir_all(&toolchain_bin).unwrap();
+    fs::create_dir_all(&base_bin).unwrap();
+    fs::create_dir_all(&venv_bin).unwrap();
+    fs::write(project.path().join(".tool-versions"), "python 3.13.3\n").unwrap();
+
+    let old_home = std::env::var("HOME").ok();
+    std::env::set_var("HOME", home.path());
+    let plan = build_activation_plan(project.path()).unwrap();
+
+    let shell = shell_path(&plan).unwrap();
+    assert!(
+        shell.starts_with(venv_bin.to_string_lossy().as_ref()),
+        "shell path was: {shell}"
+    );
+    assert!(!shell.contains(base_bin.to_string_lossy().as_ref()));
+    let exec = exec_path(&plan);
+    assert!(!exec.contains(base_bin.to_string_lossy().as_ref()));
+    assert!(exec.contains(toolchain_bin.to_string_lossy().as_ref()));
+
+    if let Some(value) = old_home {
+        std::env::set_var("HOME", value);
+    } else {
+        std::env::remove_var("HOME");
+    }
+}

--- a/src/activation/tests.rs
+++ b/src/activation/tests.rs
@@ -105,3 +105,46 @@ fn test_activation_plan_hides_python_base_inside_project_venv() {
         std::env::remove_var("HOME");
     }
 }
+
+#[test]
+fn test_activation_plan_prefers_project_node_modules_bin() {
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    let nested = project.path().join("packages/app/src");
+    let vex_dir = home.path().join(".vex");
+    let toolchain_bin = vex_dir.join("toolchains/node/24.0.0/bin");
+    let project_bin = project.path().join("node_modules/.bin");
+    let npm_bin = vex_dir.join("npm/prefix/bin");
+    fs::create_dir_all(&toolchain_bin).unwrap();
+    fs::create_dir_all(&project_bin).unwrap();
+    fs::create_dir_all(&nested).unwrap();
+    fs::write(project.path().join(".tool-versions"), "node 24.0.0\n").unwrap();
+
+    let old_home = std::env::var("HOME").ok();
+    std::env::set_var("HOME", home.path());
+    let plan = build_activation_plan(&nested).unwrap();
+
+    let shell = shell_path(&plan).unwrap();
+    assert!(
+        shell.starts_with(project_bin.to_string_lossy().as_ref()),
+        "shell path was: {shell}"
+    );
+    assert!(
+        shell.find(project_bin.to_string_lossy().as_ref()).unwrap()
+            < shell.find(npm_bin.to_string_lossy().as_ref()).unwrap(),
+        "shell path was: {shell}"
+    );
+
+    let exec = exec_path(&plan);
+    assert!(
+        exec.starts_with(project_bin.to_string_lossy().as_ref()),
+        "exec path was: {exec}"
+    );
+    assert!(exec.contains(toolchain_bin.to_string_lossy().as_ref()));
+
+    if let Some(value) = old_home {
+        std::env::set_var("HOME", value);
+    } else {
+        std::env::remove_var("HOME");
+    }
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -129,7 +129,7 @@ fn dispatch(command: Commands) -> Result<()> {
         Commands::Tui => {
             commands::tui::run()?;
         }
-        Commands::Python(args) => commands::python::run_subcommand(&args.subcmd)?,
+        Commands::Python(args) => commands::python::run_subcommand(&args.subcmd, &args.args)?,
         Commands::Rust(args) => commands::rust::run(&args)?,
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -78,6 +78,13 @@ fn dispatch(command: Commands) -> Result<()> {
         Commands::Current(args) => {
             commands::current::show(output::OutputMode::from_json_flag(args.json), args.verbose)?;
         }
+        Commands::Globals(args) => {
+            commands::globals::show(
+                args.tool.as_deref(),
+                output::OutputMode::from_json_flag(args.json),
+                args.verbose,
+            )?;
+        }
         Commands::Uninstall(args) => {
             commands::manage::uninstall_spec(&args.spec)?;
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,6 +47,9 @@ pub(crate) enum Commands {
     /// Show current active versions
     Current(listing::CurrentArgs),
 
+    /// List global CLIs and Java build-tool state managed or detected by vex
+    Globals(listing::GlobalsArgs),
+
     /// Uninstall a version
     Uninstall(manage::UninstallArgs),
 

--- a/src/cli/listing.rs
+++ b/src/cli/listing.rs
@@ -49,7 +49,8 @@ pub(crate) struct CurrentArgs {
 
 #[derive(Args)]
 pub(crate) struct GlobalsArgs {
-    /// Optional tool/ecosystem filter: node, python, go, rust, java, maven, or gradle
+    /// Optional tool/ecosystem filter: all, node, python, go, rust, java, maven, mvn, or gradle
+    #[arg(value_parser = ["all", "node", "python", "go", "rust", "java", "maven", "mvn", "gradle"])]
     pub(crate) tool: Option<String>,
 
     /// Output machine-readable JSON

--- a/src/cli/listing.rs
+++ b/src/cli/listing.rs
@@ -46,3 +46,17 @@ pub(crate) struct CurrentArgs {
     #[arg(long)]
     pub(crate) verbose: bool,
 }
+
+#[derive(Args)]
+pub(crate) struct GlobalsArgs {
+    /// Optional tool/ecosystem filter: node, python, go, rust, java, maven, or gradle
+    pub(crate) tool: Option<String>,
+
+    /// Output machine-readable JSON
+    #[arg(long)]
+    pub(crate) json: bool,
+
+    /// Show full executable and source paths in text output
+    #[arg(long)]
+    pub(crate) verbose: bool,
+}

--- a/src/cli/python.rs
+++ b/src/cli/python.rs
@@ -9,5 +9,11 @@ pub(crate) struct PythonArgs {
     ///            Use after installing packages to lock the environment.
     ///   sync   — Restore the environment from requirements.lock via `pip install -r`.
     ///            Auto-creates .venv if it does not exist yet.
+    ///   base   — Manage the active Python base environment for global Python CLIs.
     pub(crate) subcmd: String,
+
+    /// Extra arguments for nested Python subcommands, for example:
+    ///   vex python base pip install kaggle
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+    pub(crate) args: Vec<String>,
 }

--- a/src/commands/doctor/checks.rs
+++ b/src/commands/doctor/checks.rs
@@ -5,6 +5,7 @@ mod summary;
 mod system;
 
 use super::types::DoctorReport;
+use crate::commands::globals;
 use crate::config;
 use crate::error::{Result, VexError};
 use crate::resolver;
@@ -31,6 +32,8 @@ pub(super) fn collect() -> Result<DoctorReport> {
     let disk_usage = analysis::collect_disk_usage(&vex_dir)?;
     let unused_versions = analysis::collect_unused_versions(&vex_dir, &retained)?;
     let lifecycle_warnings = analysis::collect_lifecycle_warnings(&vex_dir)?;
+    let global_clis = globals::collect(None)?.entries;
+    push_global_cli_inventory_check(&global_clis, &mut checks);
 
     let total_disk_bytes = disk_usage.iter().map(|u| u.total_bytes).sum();
     let reclaimable_bytes = unused_versions.iter().map(|u| u.bytes).sum();
@@ -52,6 +55,7 @@ pub(super) fn collect() -> Result<DoctorReport> {
         issues,
         warnings,
         checks,
+        global_clis,
         disk_usage,
         unused_versions,
         lifecycle_warnings,
@@ -59,4 +63,44 @@ pub(super) fn collect() -> Result<DoctorReport> {
         reclaimable_bytes,
         suggestions,
     })
+}
+
+fn push_global_cli_inventory_check(
+    global_clis: &[globals::GlobalCliEntry],
+    checks: &mut Vec<super::types::DoctorCheck>,
+) {
+    let mut counts = std::collections::BTreeMap::<&str, usize>::new();
+    for entry in global_clis {
+        *counts.entry(entry.tool.as_str()).or_default() += 1;
+    }
+
+    let details = if counts.is_empty() {
+        Vec::new()
+    } else {
+        let mut details = counts
+            .into_iter()
+            .map(|(tool, count)| {
+                format!(
+                    "{}: {} {}",
+                    tool,
+                    count,
+                    if count == 1 { "entry" } else { "entries" }
+                )
+            })
+            .collect::<Vec<_>>();
+        details.push("Run 'vex globals --verbose' for paths and version-source hints.".to_string());
+        details
+    };
+
+    super::types::push_check(
+        checks,
+        "global_cli_inventory",
+        super::types::CheckStatus::Ok,
+        if global_clis.is_empty() {
+            "no managed global CLI entries were detected"
+        } else {
+            "global CLI inventory is available"
+        },
+        details,
+    );
 }

--- a/src/commands/doctor/checks/environment.rs
+++ b/src/commands/doctor/checks/environment.rs
@@ -2,6 +2,8 @@ use super::super::types::{push_check, CheckStatus, DoctorCheck};
 use super::system;
 use crate::config::{self, StrictMode};
 use crate::home_state::{self, AuditKind};
+use crate::tools::python;
+use crate::version_state;
 use std::path::Path;
 
 pub(super) fn collect_environment_checks(
@@ -195,6 +197,7 @@ pub(super) fn collect_environment_checks(
     collect_home_hygiene_check(warnings, issues, checks);
     collect_path_conflict_check(vex_bin, warnings, issues, checks);
     collect_captured_env_check(vex_dir, warnings, issues, checks);
+    collect_python_base_check(vex_dir, warnings, checks);
     collect_manager_conflict_check(warnings, issues, checks);
 }
 
@@ -399,6 +402,60 @@ fn collect_manager_conflict_check(
         "other version-manager homes were detected",
         details,
     );
+}
+
+fn collect_python_base_check(vex_dir: &Path, warnings: &mut usize, checks: &mut Vec<DoctorCheck>) {
+    let current_versions = match version_state::read_current_versions(vex_dir) {
+        Ok(versions) => versions,
+        Err(_) => return,
+    };
+    let Some(version) = current_versions.get("python") else {
+        push_check(
+            checks,
+            "python_base_env",
+            CheckStatus::Ok,
+            "python base environment check skipped because Python is not active",
+            Vec::new(),
+        );
+        return;
+    };
+
+    let base_dir = python::base_env_dir(vex_dir, version);
+    let base_bin = python::base_bin_dir(vex_dir, version);
+    let mut details = vec![format!("Base: {}", base_dir.display())];
+    let mut status = CheckStatus::Ok;
+    let mut summary = "python base environment is ready".to_string();
+
+    if !python::is_base_env_healthy(vex_dir, version) {
+        *warnings += 1;
+        status = CheckStatus::Warn;
+        summary = "python base environment is missing or incomplete".to_string();
+        details.push(format!(
+            "Run 'vex python base' to create the base environment for python@{}.",
+            version
+        ));
+    }
+
+    if std::env::var_os("VIRTUAL_ENV").is_some() {
+        let base_bin_str = base_bin.to_string_lossy().to_string();
+        let leaks_into_venv = std::env::var("PATH")
+            .unwrap_or_default()
+            .split(':')
+            .any(|entry| entry == base_bin_str);
+        if leaks_into_venv {
+            if status != CheckStatus::Warn {
+                *warnings += 1;
+            }
+            status = CheckStatus::Warn;
+            summary = "python base bin is active inside a virtual environment".to_string();
+            details.push(
+                "Project virtual environments should not inherit Python base CLI packages."
+                    .to_string(),
+            );
+        }
+    }
+
+    push_check(checks, "python_base_env", status, &summary, details);
 }
 
 fn strict_status(mode: StrictMode, warnings: &mut usize, issues: &mut usize) -> CheckStatus {

--- a/src/commands/doctor/render/checks.rs
+++ b/src/commands/doctor/render/checks.rs
@@ -45,6 +45,7 @@ fn check_display_name(id: &str) -> &'static str {
         "home_hygiene" => "home hygiene",
         "path_conflicts" => "PATH conflicts",
         "captured_env" => "captured environment",
+        "global_cli_inventory" => "global CLI inventory",
         "manager_conflicts" => "manager conflicts",
         "installed_tools" => "installed tools",
         "symlinks" => "symlinks integrity",

--- a/src/commands/doctor/render/sections.rs
+++ b/src/commands/doctor/render/sections.rs
@@ -4,9 +4,48 @@ use crate::ui;
 use owo_colors::OwoColorize;
 
 pub(super) fn render_sections(report: &DoctorReport) {
+    render_global_clis(report);
     render_disk_usage(report);
     render_unused_versions(report);
     render_lifecycle_warnings(report);
+}
+
+fn render_global_clis(report: &DoctorReport) {
+    if report.global_clis.is_empty() {
+        return;
+    }
+
+    ui::header("Global CLIs and Build Tool State");
+    let mut table = ui::Table::new();
+    for entry in report.global_clis.iter().take(20) {
+        let version_context = entry
+            .tool_version
+            .as_ref()
+            .map(|version| {
+                format!(
+                    "{} ({})",
+                    version,
+                    entry.version_source.as_deref().unwrap_or("unknown source")
+                )
+            })
+            .unwrap_or_else(|| "n/a".to_string());
+        table = table.row(vec![
+            entry.tool.yellow().to_string(),
+            entry.name.cyan().to_string(),
+            entry.source.clone(),
+            version_context.dimmed().to_string(),
+        ]);
+    }
+    table.render();
+    println!();
+    if report.global_clis.len() > 20 {
+        println!(
+            "  {} (showing 20 of {}; run 'vex globals --verbose' for the full inventory)",
+            "...".dimmed(),
+            report.global_clis.len()
+        );
+        println!();
+    }
 }
 
 fn render_disk_usage(report: &DoctorReport) {

--- a/src/commands/doctor/types.rs
+++ b/src/commands/doctor/types.rs
@@ -1,5 +1,7 @@
 use serde::Serialize;
 
+use crate::commands::globals::GlobalCliEntry;
+
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum CheckStatus {
@@ -44,6 +46,7 @@ pub struct DoctorReport {
     pub issues: usize,
     pub warnings: usize,
     pub checks: Vec<DoctorCheck>,
+    pub global_clis: Vec<GlobalCliEntry>,
     pub disk_usage: Vec<ToolDiskUsage>,
     pub unused_versions: Vec<UnusedVersion>,
     pub lifecycle_warnings: Vec<LifecycleWarning>,

--- a/src/commands/globals.rs
+++ b/src/commands/globals.rs
@@ -326,6 +326,7 @@ fn is_user_python_cli(name: &str) -> bool {
         || name.starts_with("Activate.")
         || name == "python"
         || name.starts_with("python3")
+        || name == "\u{1d70b}thon"
         || name == "pip"
         || name.starts_with("pip3"))
 }
@@ -473,6 +474,36 @@ mod tests {
             .entries
             .iter()
             .any(|entry| entry.name == "gradle-caches"));
+
+        if let Some(home) = old_home {
+            std::env::set_var("HOME", home);
+        } else {
+            std::env::remove_var("HOME");
+        }
+    }
+
+    #[test]
+    fn collect_python_base_reports_user_clis_only() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let home = TempDir::new().unwrap();
+        let old_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", home.path());
+
+        let bin_dir = home.path().join(".vex/python/base/3.14.4/bin");
+        fs::create_dir_all(&bin_dir).unwrap();
+        write_executable(&bin_dir.join("kaggle"));
+        write_executable(&bin_dir.join("pip"));
+        write_executable(&bin_dir.join("python3.14"));
+        write_executable(&bin_dir.join("\u{1d70b}thon"));
+
+        let report = collect(Some("python")).unwrap();
+        assert!(report
+            .entries
+            .iter()
+            .any(|entry| entry.tool == "python" && entry.name == "kaggle"));
+        assert!(!report.entries.iter().any(|entry| entry.name == "pip"
+            || entry.name == "python3.14"
+            || entry.name == "\u{1d70b}thon"));
 
         if let Some(home) = old_home {
             std::env::set_var("HOME", home);

--- a/src/commands/globals.rs
+++ b/src/commands/globals.rs
@@ -1,0 +1,483 @@
+use crate::commands::current;
+use crate::config;
+use crate::error::{Result, VexError};
+use crate::output::{print_json, OutputMode};
+use crate::tools::python;
+use crate::ui;
+use owo_colors::OwoColorize;
+use serde::Serialize;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GlobalCliEntry {
+    pub tool: String,
+    pub name: String,
+    pub kind: String,
+    pub path: String,
+    pub source: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version_source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version_source_path: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct GlobalsReport {
+    pub cwd: String,
+    pub entries: Vec<GlobalCliEntry>,
+}
+
+#[derive(Debug, Clone)]
+struct VersionContext {
+    version: String,
+    source: String,
+    source_path: Option<String>,
+}
+
+pub fn show(tool_filter: Option<&str>, output: OutputMode, verbose: bool) -> Result<()> {
+    let report = collect(tool_filter)?;
+    match output {
+        OutputMode::Json => print_json(&report),
+        OutputMode::Text => {
+            render_text(&report, verbose);
+            Ok(())
+        }
+    }
+}
+
+pub fn collect(tool_filter: Option<&str>) -> Result<GlobalsReport> {
+    let vex_dir = config::vex_home().ok_or(VexError::HomeDirectoryNotFound)?;
+    let cwd = std::env::current_dir()?;
+    let contexts = current_contexts().unwrap_or_default();
+    let mut entries = Vec::new();
+
+    collect_node_entries(&vex_dir, &contexts, tool_filter, &mut entries);
+    collect_python_entries(&vex_dir, &contexts, tool_filter, &mut entries)?;
+    collect_go_entries(&vex_dir, &contexts, tool_filter, &mut entries);
+    collect_rust_entries(&vex_dir, &contexts, tool_filter, &mut entries);
+    collect_java_entries(&contexts, tool_filter, &mut entries);
+
+    entries.sort_by(|left, right| {
+        left.tool
+            .cmp(&right.tool)
+            .then(left.kind.cmp(&right.kind))
+            .then(left.name.cmp(&right.name))
+            .then(left.path.cmp(&right.path))
+    });
+
+    Ok(GlobalsReport {
+        cwd: cwd.display().to_string(),
+        entries,
+    })
+}
+
+fn current_contexts() -> Result<BTreeMap<String, VersionContext>> {
+    Ok(current::collect_current()?
+        .tools
+        .into_iter()
+        .map(|entry| {
+            (
+                entry.tool,
+                VersionContext {
+                    version: entry.version,
+                    source: entry.source,
+                    source_path: entry.source_path,
+                },
+            )
+        })
+        .collect())
+}
+
+fn collect_node_entries(
+    vex_dir: &Path,
+    contexts: &BTreeMap<String, VersionContext>,
+    filter: Option<&str>,
+    entries: &mut Vec<GlobalCliEntry>,
+) {
+    if !matches_filter(filter, "node", "") {
+        return;
+    }
+    let bin_dir = vex_dir.join("npm/prefix/bin");
+    push_bin_entries(
+        entries,
+        "node",
+        "npm_global",
+        "managed npm prefix",
+        &bin_dir,
+        contexts.get("node"),
+        |_| true,
+    );
+}
+
+fn collect_python_entries(
+    vex_dir: &Path,
+    contexts: &BTreeMap<String, VersionContext>,
+    filter: Option<&str>,
+    entries: &mut Vec<GlobalCliEntry>,
+) -> Result<()> {
+    if !matches_filter(filter, "python", "") {
+        return Ok(());
+    }
+
+    let base_root = vex_dir.join("python/base");
+    if !base_root.exists() {
+        return Ok(());
+    }
+
+    for version_entry in fs::read_dir(base_root)?.filter_map(|entry| entry.ok()) {
+        let Ok(file_type) = version_entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+
+        let version = version_entry.file_name().to_string_lossy().to_string();
+        let bin_dir = python::base_bin_dir(vex_dir, &version);
+        let active_context = contexts
+            .get("python")
+            .filter(|context| context.version == version);
+        push_bin_entries(
+            entries,
+            "python",
+            "python_base",
+            "Python base environment",
+            &bin_dir,
+            active_context,
+            is_user_python_cli,
+        );
+
+        for entry in entries.iter_mut().filter(|entry| {
+            entry.tool == "python"
+                && entry.kind == "python_base"
+                && entry.path.starts_with(&bin_dir.display().to_string())
+        }) {
+            entry.tool_version = Some(version.clone());
+        }
+    }
+
+    Ok(())
+}
+
+fn collect_go_entries(
+    vex_dir: &Path,
+    contexts: &BTreeMap<String, VersionContext>,
+    filter: Option<&str>,
+    entries: &mut Vec<GlobalCliEntry>,
+) {
+    if !matches_filter(filter, "go", "") {
+        return;
+    }
+    let bin_dir = vex_dir.join("go/bin");
+    push_bin_entries(
+        entries,
+        "go",
+        "go_global",
+        "managed GOBIN",
+        &bin_dir,
+        contexts.get("go"),
+        |_| true,
+    );
+}
+
+fn collect_rust_entries(
+    vex_dir: &Path,
+    contexts: &BTreeMap<String, VersionContext>,
+    filter: Option<&str>,
+    entries: &mut Vec<GlobalCliEntry>,
+) {
+    if !matches_filter(filter, "rust", "") {
+        return;
+    }
+    let bin_dir = vex_dir.join("cargo/bin");
+    push_bin_entries(
+        entries,
+        "rust",
+        "cargo_global",
+        "managed CARGO_HOME bin",
+        &bin_dir,
+        contexts.get("rust"),
+        |_| true,
+    );
+}
+
+fn collect_java_entries(
+    contexts: &BTreeMap<String, VersionContext>,
+    filter: Option<&str>,
+    entries: &mut Vec<GlobalCliEntry>,
+) {
+    if !matches_filter(filter, "java", "") {
+        return;
+    }
+
+    let context = contexts.get("java");
+    let mut seen_paths = BTreeSet::new();
+    for (name, source) in [
+        ("mvn", "external Maven CLI on PATH"),
+        ("gradle", "external Gradle CLI on PATH"),
+    ] {
+        if !matches_filter(filter, "java", name) {
+            continue;
+        }
+        if let Some(path) = find_on_path(name) {
+            if seen_paths.insert(path.clone()) {
+                entries.push(entry_from_path(
+                    "java",
+                    name,
+                    if name == "mvn" {
+                        "maven_cli"
+                    } else {
+                        "gradle_cli"
+                    },
+                    source,
+                    &path,
+                    context,
+                ));
+            }
+        }
+    }
+
+    let Some(home) = dirs::home_dir() else {
+        return;
+    };
+    for (name, kind, source, path) in [
+        (
+            "maven-local-repository",
+            "maven_state",
+            "Maven local repository outside vex",
+            home.join(".m2/repository"),
+        ),
+        (
+            "gradle-caches",
+            "gradle_state",
+            "Gradle caches outside vex",
+            home.join(".gradle/caches"),
+        ),
+        (
+            "gradle-wrapper-cache",
+            "gradle_state",
+            "Gradle wrapper distributions outside vex",
+            home.join(".gradle/wrapper"),
+        ),
+    ] {
+        if path.exists() && matches_filter(filter, "java", name) {
+            entries.push(entry_from_path("java", name, kind, source, &path, context));
+        }
+    }
+}
+
+fn push_bin_entries(
+    entries: &mut Vec<GlobalCliEntry>,
+    tool: &str,
+    kind: &str,
+    source: &str,
+    bin_dir: &Path,
+    context: Option<&VersionContext>,
+    include_name: impl Fn(&str) -> bool,
+) {
+    if !bin_dir.exists() {
+        return;
+    }
+
+    let Ok(read_dir) = fs::read_dir(bin_dir) else {
+        return;
+    };
+
+    for entry in read_dir.filter_map(|entry| entry.ok()) {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name.starts_with('.') || !include_name(&name) {
+            continue;
+        }
+        let path = entry.path();
+        if is_executable_file(&path) {
+            entries.push(entry_from_path(tool, &name, kind, source, &path, context));
+        }
+    }
+}
+
+fn entry_from_path(
+    tool: &str,
+    name: &str,
+    kind: &str,
+    source: &str,
+    path: &Path,
+    context: Option<&VersionContext>,
+) -> GlobalCliEntry {
+    GlobalCliEntry {
+        tool: tool.to_string(),
+        name: name.to_string(),
+        kind: kind.to_string(),
+        path: path.display().to_string(),
+        source: source.to_string(),
+        tool_version: context.map(|context| context.version.clone()),
+        version_source: context.map(|context| context.source.clone()),
+        version_source_path: context.and_then(|context| context.source_path.clone()),
+    }
+}
+
+fn is_user_python_cli(name: &str) -> bool {
+    !(name == "activate"
+        || name.starts_with("activate.")
+        || name.starts_with("Activate.")
+        || name == "python"
+        || name.starts_with("python3")
+        || name == "pip"
+        || name.starts_with("pip3"))
+}
+
+fn is_executable_file(path: &Path) -> bool {
+    let Ok(metadata) = fs::metadata(path) else {
+        return false;
+    };
+    if metadata.is_dir() {
+        return false;
+    }
+    metadata.permissions().mode() & 0o111 != 0
+}
+
+fn find_on_path(name: &str) -> Option<PathBuf> {
+    std::env::var("PATH").ok()?.split(':').find_map(|entry| {
+        if entry.is_empty() {
+            return None;
+        }
+        let candidate = Path::new(entry).join(name);
+        is_executable_file(&candidate).then_some(candidate)
+    })
+}
+
+fn matches_filter(filter: Option<&str>, tool: &str, name: &str) -> bool {
+    let Some(filter) = filter else {
+        return true;
+    };
+    let filter = filter.to_ascii_lowercase();
+    match filter.as_str() {
+        "all" => true,
+        "maven" => tool == "java" && (name.is_empty() || name.contains("maven") || name == "mvn"),
+        "gradle" => tool == "java" && (name.is_empty() || name.contains("gradle")),
+        _ => filter == tool || (!name.is_empty() && filter == name),
+    }
+}
+
+fn render_text(report: &GlobalsReport, verbose: bool) {
+    if report.entries.is_empty() {
+        ui::dimmed("No global CLI entries detected.");
+        println!();
+        ui::dimmed("Install a global CLI with npm, Go, Cargo, or 'vex python base pip'.");
+        return;
+    }
+
+    ui::header("Global CLIs and Build Tool State");
+    let mut table = ui::Table::new();
+    for entry in &report.entries {
+        let version_context = entry
+            .tool_version
+            .as_ref()
+            .map(|version| {
+                format!(
+                    "{} ({})",
+                    version,
+                    entry.version_source.as_deref().unwrap_or("unknown source")
+                )
+            })
+            .unwrap_or_else(|| "n/a".to_string());
+        table = table.row(vec![
+            entry.tool.yellow().to_string(),
+            entry.name.cyan().to_string(),
+            entry.source.clone(),
+            version_context.dimmed().to_string(),
+        ]);
+        if verbose {
+            table = table.row(vec![
+                "".to_string(),
+                "".to_string(),
+                format!("{}: {}", "Path".dimmed(), entry.path.dimmed()),
+                entry
+                    .version_source_path
+                    .as_ref()
+                    .map(|path| format!("{}: {}", "Version source".dimmed(), path.dimmed()))
+                    .unwrap_or_default(),
+            ]);
+        }
+    }
+    table.render();
+    println!();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    use tempfile::TempDir;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn write_executable(path: &Path) {
+        fs::write(path, "#!/bin/sh\n").unwrap();
+        let mut perms = fs::metadata(path).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms).unwrap();
+    }
+
+    #[test]
+    fn collect_reports_go_and_rust_global_bins() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let home = TempDir::new().unwrap();
+        let old_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", home.path());
+
+        let go_bin = home.path().join(".vex/go/bin");
+        let cargo_bin = home.path().join(".vex/cargo/bin");
+        fs::create_dir_all(&go_bin).unwrap();
+        fs::create_dir_all(&cargo_bin).unwrap();
+        write_executable(&go_bin.join("gopls"));
+        write_executable(&cargo_bin.join("cargo-audit"));
+
+        let report = collect(None).unwrap();
+        assert!(report
+            .entries
+            .iter()
+            .any(|entry| entry.tool == "go" && entry.name == "gopls"));
+        assert!(report
+            .entries
+            .iter()
+            .any(|entry| entry.tool == "rust" && entry.name == "cargo-audit"));
+
+        if let Some(home) = old_home {
+            std::env::set_var("HOME", home);
+        } else {
+            std::env::remove_var("HOME");
+        }
+    }
+
+    #[test]
+    fn collect_reports_java_build_state() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let home = TempDir::new().unwrap();
+        let old_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", home.path());
+
+        fs::create_dir_all(home.path().join(".m2/repository")).unwrap();
+        fs::create_dir_all(home.path().join(".gradle/caches")).unwrap();
+
+        let report = collect(Some("java")).unwrap();
+        assert!(report
+            .entries
+            .iter()
+            .any(|entry| entry.name == "maven-local-repository"));
+        assert!(report
+            .entries
+            .iter()
+            .any(|entry| entry.name == "gradle-caches"));
+
+        if let Some(home) = old_home {
+            std::env::set_var("HOME", home);
+        } else {
+            std::env::remove_var("HOME");
+        }
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod aliases;
 pub mod current;
 pub mod doctor;
+pub mod globals;
 pub mod init;
 pub mod manage;
 pub mod process;

--- a/src/commands/python.rs
+++ b/src/commands/python.rs
@@ -5,13 +5,14 @@ mod workflow;
 
 use crate::error::{Result, VexError};
 
-pub fn run_subcommand(subcmd: &str) -> Result<()> {
+pub fn run_subcommand(subcmd: &str, args: &[String]) -> Result<()> {
     match subcmd {
         "init" => init(),
         "freeze" => freeze(),
         "sync" => sync(),
+        "base" => base(args),
         _ => Err(VexError::Parse(format!(
-            "Unknown python subcommand: '{}'. Available: init, freeze, sync",
+            "Unknown python subcommand: '{}'. Available: init, freeze, sync, base",
             subcmd
         ))),
     }
@@ -27,4 +28,8 @@ pub fn freeze() -> Result<()> {
 
 pub fn sync() -> Result<()> {
     workflow::sync()
+}
+
+pub fn base(args: &[String]) -> Result<()> {
+    workflow::base(args)
 }

--- a/src/commands/python/workflow.rs
+++ b/src/commands/python/workflow.rs
@@ -1,11 +1,13 @@
 use super::env::find_active_python_bin;
 use crate::error::{Result, VexError};
+use crate::paths::vex_dir;
 use crate::resolver;
+use crate::tools::python;
 use crate::version_files;
 use owo_colors::OwoColorize;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 pub(super) fn init() -> Result<()> {
     let cwd = resolver::current_dir();
@@ -106,6 +108,37 @@ pub(super) fn sync() -> Result<()> {
     Ok(())
 }
 
+pub(super) fn base(args: &[String]) -> Result<()> {
+    match args.first().map(String::as_str) {
+        None | Some("ensure") => {
+            let (version, base_dir) = ensure_active_base()?;
+            println!(
+                "{} Python base environment is ready for python@{}",
+                "✓".green(),
+                version.cyan()
+            );
+            println!("{}", format!("  Base: {}", base_dir.display()).dimmed());
+            println!(
+                "{}",
+                "  Use it for global Python CLIs when no project .venv is active.".dimmed()
+            );
+            Ok(())
+        }
+        Some("path") => {
+            let (_version, base_dir) = ensure_active_base()?;
+            println!("{}", base_dir.display());
+            Ok(())
+        }
+        Some("pip") => run_base_pip(&args[1..]),
+        Some("freeze") => freeze_base(),
+        Some("sync") => sync_base(),
+        Some(other) => Err(VexError::Parse(format!(
+            "Unknown python base subcommand: '{}'. Available: ensure, path, pip, freeze, sync",
+            other
+        ))),
+    }
+}
+
 fn record_python_version(cwd: &Path) -> Result<()> {
     let versions = resolver::resolve_versions(cwd);
     if let Some((_, version)) = versions.iter().find(|(tool, _)| tool.as_str() == "python") {
@@ -123,4 +156,119 @@ fn record_python_version(cwd: &Path) -> Result<()> {
 
 fn pip_path(cwd: &Path) -> PathBuf {
     cwd.join(".venv").join("bin").join("pip")
+}
+
+fn ensure_active_base() -> Result<(String, PathBuf)> {
+    let vex = vex_dir()?;
+    let (version, install_dir) = active_python_install(&vex)?;
+    let base_dir = python::ensure_base_environment(&vex, &version, &install_dir)?;
+    Ok((version, base_dir))
+}
+
+fn active_python_install(vex: &Path) -> Result<(String, PathBuf)> {
+    let current_link = vex.join("current").join("python");
+    let target = fs::read_link(&current_link).map_err(|_| {
+        VexError::PythonEnv(
+            "No active vex-managed Python found. Run 'vex use python@<version>' first.".to_string(),
+        )
+    })?;
+    let install_dir = if target.is_absolute() {
+        target
+    } else {
+        current_link.parent().unwrap_or(vex).join(target)
+    };
+    let version = install_dir
+        .file_name()
+        .ok_or_else(|| {
+            VexError::PythonEnv(format!(
+                "Could not determine Python version from {}",
+                install_dir.display()
+            ))
+        })?
+        .to_string_lossy()
+        .to_string();
+
+    Ok((version, install_dir))
+}
+
+fn run_base_pip(args: &[String]) -> Result<()> {
+    let (version, _base_dir) = ensure_active_base()?;
+    if args.is_empty() {
+        return Err(VexError::Parse(
+            "Usage: vex python base pip <pip-args...>".to_string(),
+        ));
+    }
+
+    let pip = python::base_pip_bin(&vex_dir()?, &version);
+    let status = Command::new(&pip)
+        .args(args)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()?;
+
+    if !status.success() {
+        return Err(VexError::PythonEnv(format!(
+            "Base pip command failed for python@{}",
+            version
+        )));
+    }
+
+    Ok(())
+}
+
+fn freeze_base() -> Result<()> {
+    let (version, base_dir) = ensure_active_base()?;
+    let pip = python::base_pip_bin(&vex_dir()?, &version);
+    let output = Command::new(&pip).arg("freeze").output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(VexError::PythonEnv(format!(
+            "Base pip freeze failed for python@{}: {}",
+            version,
+            stderr.trim()
+        )));
+    }
+
+    let lock_path = base_dir.join("requirements.lock");
+    fs::write(&lock_path, &output.stdout)?;
+    let line_count = output.stdout.iter().filter(|&&byte| byte == b'\n').count();
+    println!(
+        "{} Wrote {} base packages to {}",
+        "✓".green(),
+        line_count,
+        lock_path.display().to_string().cyan()
+    );
+    Ok(())
+}
+
+fn sync_base() -> Result<()> {
+    let (version, base_dir) = ensure_active_base()?;
+    let lock_path = base_dir.join("requirements.lock");
+    if !lock_path.exists() {
+        return Err(VexError::PythonEnv(format!(
+            "No base requirements.lock found for python@{}. Run 'vex python base freeze' first.",
+            version
+        )));
+    }
+
+    let pip = python::base_pip_bin(&vex_dir()?, &version);
+    let status = Command::new(&pip)
+        .arg("install")
+        .arg("-r")
+        .arg(&lock_path)
+        .status()?;
+    if !status.success() {
+        return Err(VexError::PythonEnv(format!(
+            "Base pip sync failed for python@{}",
+            version
+        )));
+    }
+
+    println!(
+        "{} Python base environment restored from {}",
+        "✓".green(),
+        lock_path.display().to_string().cyan()
+    );
+    Ok(())
 }

--- a/src/commands/versions/filter.rs
+++ b/src/commands/versions/filter.rs
@@ -20,7 +20,14 @@ pub(super) fn apply_filter(
                     .collect()
             }
         }
+        RemoteFilter::Major if tool_name == "python" => {
+            newest_patch_per_major(preferred_python_versions(versions))
+        }
         RemoteFilter::Major => newest_patch_per_major(versions),
+        RemoteFilter::Latest if tool_name == "python" => preferred_python_versions(versions)
+            .into_iter()
+            .take(1)
+            .collect(),
         RemoteFilter::Latest => versions.into_iter().take(1).collect(),
     }
 }
@@ -59,6 +66,19 @@ fn newest_patch_per_major(versions: Vec<Version>) -> Vec<Version> {
         .collect();
     result.sort_by_key(|version| Reverse(version_sort_key(&version.version)));
     result
+}
+
+fn preferred_python_versions(versions: Vec<Version>) -> Vec<Version> {
+    let stable = versions
+        .iter()
+        .filter(|version| matches!(version.lts.as_deref(), Some("bugfix" | "security")))
+        .cloned()
+        .collect::<Vec<_>>();
+    if stable.is_empty() {
+        versions
+    } else {
+        stable
+    }
 }
 
 fn extract_major_version(version: &str) -> String {

--- a/src/commands/versions/tests.rs
+++ b/src/commands/versions/tests.rs
@@ -33,3 +33,59 @@ fn test_major_filter_keeps_newest_patch_per_major() {
         .collect::<Vec<_>>();
     assert_eq!(versions, vec!["20.10.0", "19.8.1"]);
 }
+
+#[test]
+fn test_python_latest_filter_skips_feature_prereleases() {
+    let filtered = apply_filter(
+        "python",
+        vec![
+            Version {
+                version: "3.15.0a8".to_string(),
+                lts: Some("feature".to_string()),
+            },
+            Version {
+                version: "3.14.4".to_string(),
+                lts: Some("bugfix".to_string()),
+            },
+            Version {
+                version: "3.13.12".to_string(),
+                lts: Some("security".to_string()),
+            },
+        ],
+        RemoteFilter::Latest,
+    );
+
+    let versions = filtered
+        .into_iter()
+        .map(|version| version.version)
+        .collect::<Vec<_>>();
+    assert_eq!(versions, vec!["3.14.4"]);
+}
+
+#[test]
+fn test_python_major_filter_prefers_supported_stable_versions() {
+    let filtered = apply_filter(
+        "python",
+        vec![
+            Version {
+                version: "3.15.0a8".to_string(),
+                lts: Some("feature".to_string()),
+            },
+            Version {
+                version: "3.14.4".to_string(),
+                lts: Some("bugfix".to_string()),
+            },
+            Version {
+                version: "3.13.12".to_string(),
+                lts: Some("security".to_string()),
+            },
+        ],
+        RemoteFilter::Major,
+    );
+
+    let versions = filtered
+        .into_iter()
+        .map(|version| version.version)
+        .collect::<Vec<_>>();
+    assert_eq!(versions, vec!["3.14.4"]);
+}

--- a/src/home_state.rs
+++ b/src/home_state.rs
@@ -133,6 +133,18 @@ fn definitions(home: &Path) -> Vec<HomeStateAudit> {
             "pyenv installs are outside ~/.vex and need manual cleanup",
             home.join(".pyenv"),
         ),
+        advisory(
+            "maven_local_repository",
+            "java",
+            "Maven local repository is outside ~/.vex; prefer project mvnw and keep this as external build-tool state",
+            home.join(".m2/repository"),
+        ),
+        advisory(
+            "gradle_home",
+            "java",
+            "Gradle home is outside ~/.vex; prefer project gradlew and keep this as external build-tool state",
+            home.join(".gradle"),
+        ),
     ]
 }
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -1,7 +1,7 @@
 mod discovery;
 
 use crate::error::{Result, VexError};
-pub use discovery::{find_nearest_project_file, find_nearest_venv};
+pub use discovery::{find_nearest_node_modules_bin, find_nearest_project_file, find_nearest_venv};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fs;

--- a/src/project/discovery.rs
+++ b/src/project/discovery.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 
 const PROJECT_CONFIG_FILE: &str = ".vex.toml";
 const PROJECT_VENV_DIR: &str = ".venv";
+const NODE_MODULES_BIN_DIR: &str = "node_modules/.bin";
 
 pub fn find_nearest_project_file(start_dir: &Path) -> Option<PathBuf> {
     find_in_ancestors(start_dir, PROJECT_CONFIG_FILE)
@@ -9,6 +10,10 @@ pub fn find_nearest_project_file(start_dir: &Path) -> Option<PathBuf> {
 
 pub fn find_nearest_venv(start_dir: &Path) -> Option<PathBuf> {
     find_in_ancestors(start_dir, PROJECT_VENV_DIR)
+}
+
+pub fn find_nearest_node_modules_bin(start_dir: &Path) -> Option<PathBuf> {
+    find_in_ancestors(start_dir, NODE_MODULES_BIN_DIR)
 }
 
 fn find_in_ancestors(start_dir: &Path, file_name: &str) -> Option<PathBuf> {

--- a/src/project/tests.rs
+++ b/src/project/tests.rs
@@ -93,3 +93,15 @@ fn test_find_nearest_venv() {
     let venv = find_nearest_venv(&nested).expect("venv should be found");
     assert_eq!(venv, project.join(".venv"));
 }
+
+#[test]
+fn test_find_nearest_node_modules_bin() {
+    let temp = TempDir::new().unwrap();
+    let project = temp.path().join("project");
+    let nested = project.join("packages/app/src");
+    fs::create_dir_all(project.join("node_modules/.bin")).unwrap();
+    fs::create_dir_all(&nested).unwrap();
+
+    let bin = find_nearest_node_modules_bin(&nested).expect("node_modules/.bin should be found");
+    assert_eq!(bin, project.join("node_modules/.bin"));
+}

--- a/src/switcher.rs
+++ b/src/switcher.rs
@@ -56,6 +56,11 @@ fn switch_version_in(tool: &dyn Tool, version: &str, base_dir: &Path) -> Result<
 
     match links::perform_switch(tool, base_dir, &toolchain_dir) {
         Ok(_) => {
+            if let Err(err) = tool.post_switch(base_dir, &toolchain_dir, version) {
+                warn!("Post-switch setup failed: {}, attempting rollback", err);
+                attempt_rollback(tool, base_dir, old_version.as_deref());
+                return Err(err);
+            }
             println!("{} Switched to {}@{}", "✓".green(), tool.name(), version);
             Ok(())
         }

--- a/src/switcher/links.rs
+++ b/src/switcher/links.rs
@@ -61,7 +61,9 @@ fn update_bin_links(tool: &dyn Tool, base_dir: &Path, toolchain_dir: &Path) -> R
 
     let bin_paths = tool.bin_paths();
     let mut new_binaries = link_declared_binaries(toolchain_dir, &bin_dir, &bin_paths)?;
-    link_dynamic_binaries(toolchain_dir, &bin_dir, &bin_paths, &mut new_binaries)?;
+    if tool.link_dynamic_binaries() {
+        link_dynamic_binaries(toolchain_dir, &bin_dir, &bin_paths, &mut new_binaries)?;
+    }
     cleanup_stale_bin_links(tool, &bin_dir, &new_binaries);
 
     Ok(())

--- a/src/switcher/tests.rs
+++ b/src/switcher/tests.rs
@@ -2,8 +2,9 @@ use super::*;
 use crate::tools::go::GoTool;
 use crate::tools::node::NodeTool;
 use crate::tools::rust::RustTool;
+use crate::tools::{Arch, Tool, Version};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub(crate) fn make_temp_dir(name: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!("vex_switcher_test_{}", name));
@@ -417,6 +418,73 @@ fn test_switch_rolls_back_when_bin_link_update_fails() {
             target.display()
         );
     }
+
+    let _ = fs::remove_dir_all(&base);
+}
+
+struct PostSwitchFailTool;
+
+impl Tool for PostSwitchFailTool {
+    fn name(&self) -> &str {
+        "failswitch"
+    }
+
+    fn list_remote(&self) -> Result<Vec<Version>> {
+        Ok(Vec::new())
+    }
+
+    fn download_url(&self, _version: &str, _arch: Arch) -> Result<String> {
+        Ok(String::new())
+    }
+
+    fn checksum_url(&self, _version: &str, _arch: Arch) -> Option<String> {
+        None
+    }
+
+    fn bin_names(&self) -> Vec<&str> {
+        vec!["failswitch"]
+    }
+
+    fn bin_subpath(&self) -> &str {
+        "bin"
+    }
+
+    fn post_switch(&self, _vex_dir: &Path, _install_dir: &Path, _version: &str) -> Result<()> {
+        Err(VexError::Parse("post-switch failed".to_string()))
+    }
+}
+
+#[test]
+fn test_switch_rolls_back_when_post_switch_fails() {
+    let base = make_temp_dir("rollback_on_post_switch_failure");
+
+    let tc_v1 = base.join("toolchains/failswitch/1.0.0/bin");
+    let tc_v2 = base.join("toolchains/failswitch/2.0.0/bin");
+    fs::create_dir_all(&tc_v1).unwrap();
+    fs::create_dir_all(&tc_v2).unwrap();
+    fs::write(tc_v1.join("failswitch"), "v1").unwrap();
+    fs::write(tc_v2.join("failswitch"), "v2").unwrap();
+
+    fs::create_dir_all(base.join("current")).unwrap();
+    fs::create_dir_all(base.join("bin")).unwrap();
+    std::os::unix::fs::symlink(
+        base.join("toolchains/failswitch/1.0.0"),
+        base.join("current/failswitch"),
+    )
+    .unwrap();
+    std::os::unix::fs::symlink(tc_v1.join("failswitch"), base.join("bin/failswitch")).unwrap();
+
+    let err = switch_version_in(&PostSwitchFailTool, "2.0.0", &base)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("post-switch failed"));
+
+    let current_target = fs::read_link(base.join("current/failswitch")).unwrap();
+    assert!(current_target.ends_with("toolchains/failswitch/1.0.0"));
+    let bin_target = fs::read_link(base.join("bin/failswitch")).unwrap();
+    assert!(bin_target
+        .to_string_lossy()
+        .contains("/toolchains/failswitch/1.0.0/"));
 
     let _ = fs::remove_dir_all(&base);
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -95,6 +95,17 @@ pub trait Tool: Send + Sync {
         Ok(())
     }
 
+    /// Post-switch hook for tool-specific active-version setup, defaults to no-op.
+    /// A failure rolls the switch back to the previous active version.
+    fn post_switch(&self, _vex_dir: &Path, _install_dir: &Path, _version: &str) -> Result<()> {
+        Ok(())
+    }
+
+    /// Whether executable files not declared by [`Tool::bin_paths`] should be linked into `~/.vex/bin`.
+    fn link_dynamic_binaries(&self) -> bool {
+        true
+    }
+
     /// Return managed user-state directories and environment variables for this tool.
     fn managed_environment(&self, _vex_dir: &Path, _install_dir: Option<&Path>) -> ToolEnvironment {
         ToolEnvironment::default()

--- a/src/tools/python.rs
+++ b/src/tools/python.rs
@@ -5,6 +5,7 @@
 //! support lifecycle (bugfix, security, end-of-life).
 
 mod aliases;
+mod base;
 mod install;
 mod lifecycle;
 mod releases;
@@ -22,6 +23,10 @@ use releases::{
 };
 use std::collections::BTreeMap;
 use tracing::warn;
+
+pub use base::{
+    base_bin_dir, base_env_dir, base_pip_bin, ensure_base_environment, is_base_env_healthy,
+};
 
 /// Python tool (python-build-standalone prebuilt CPython)
 pub struct PythonTool;
@@ -123,19 +128,44 @@ impl Tool for PythonTool {
         rewire_placeholder_binaries(install_dir)
     }
 
+    fn post_switch(
+        &self,
+        vex_dir: &std::path::Path,
+        install_dir: &std::path::Path,
+        version: &str,
+    ) -> Result<()> {
+        ensure_base_environment(vex_dir, version, install_dir).map(|_| ())
+    }
+
+    fn link_dynamic_binaries(&self) -> bool {
+        false
+    }
+
     fn managed_environment(
         &self,
         vex_dir: &std::path::Path,
-        _install_dir: Option<&std::path::Path>,
+        install_dir: Option<&std::path::Path>,
     ) -> ToolEnvironment {
         let pip_cache = vex_dir.join("pip/cache");
+        let managed_user_bin_dirs = install_dir
+            .and_then(|path| path.file_name())
+            .map(|version| {
+                vec![base_bin_dir(vex_dir, &version.to_string_lossy())
+                    .display()
+                    .to_string()]
+            })
+            .unwrap_or_default();
+
         ToolEnvironment {
             managed_env: BTreeMap::from([(
                 "PIP_CACHE_DIR".to_string(),
                 pip_cache.display().to_string(),
             )]),
-            managed_user_bin_dirs: Vec::new(),
-            owned_home_dirs: vec![pip_cache.display().to_string()],
+            managed_user_bin_dirs,
+            owned_home_dirs: vec![
+                pip_cache.display().to_string(),
+                base::base_root(vex_dir).display().to_string(),
+            ],
             project_owned_dirs: vec![".venv".to_string()],
         }
     }

--- a/src/tools/python/base.rs
+++ b/src/tools/python/base.rs
@@ -1,0 +1,79 @@
+use crate::error::{Result, VexError};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+pub fn base_root(vex_dir: &Path) -> PathBuf {
+    vex_dir.join("python").join("base")
+}
+
+pub fn base_env_dir(vex_dir: &Path, version: &str) -> PathBuf {
+    base_root(vex_dir).join(version)
+}
+
+pub fn base_bin_dir(vex_dir: &Path, version: &str) -> PathBuf {
+    base_env_dir(vex_dir, version).join("bin")
+}
+
+pub fn base_python_bin(vex_dir: &Path, version: &str) -> PathBuf {
+    base_bin_dir(vex_dir, version).join("python")
+}
+
+pub fn base_pip_bin(vex_dir: &Path, version: &str) -> PathBuf {
+    base_bin_dir(vex_dir, version).join("pip")
+}
+
+pub fn is_base_env_healthy(vex_dir: &Path, version: &str) -> bool {
+    base_python_bin(vex_dir, version).exists() && base_pip_bin(vex_dir, version).exists()
+}
+
+pub fn ensure_base_environment(
+    vex_dir: &Path,
+    version: &str,
+    install_dir: &Path,
+) -> Result<PathBuf> {
+    let base_dir = base_env_dir(vex_dir, version);
+    if is_base_env_healthy(vex_dir, version) {
+        return Ok(base_dir);
+    }
+
+    if base_dir.exists() {
+        return Err(VexError::PythonEnv(format!(
+            "Python base environment exists but is incomplete: {}. Remove it and run 'vex python base' to recreate it.",
+            base_dir.display()
+        )));
+    }
+
+    fs::create_dir_all(base_root(vex_dir))?;
+    let python = toolchain_python_bin(install_dir)?;
+    let output = Command::new(&python)
+        .args(["-m", "venv"])
+        .arg(&base_dir)
+        .output()?;
+
+    if !output.status.success() {
+        let _ = fs::remove_dir_all(&base_dir);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(VexError::PythonEnv(format!(
+            "Failed to create Python base environment with {}: {}",
+            python.display(),
+            stderr.trim()
+        )));
+    }
+
+    Ok(base_dir)
+}
+
+fn toolchain_python_bin(install_dir: &Path) -> Result<PathBuf> {
+    for name in ["python3", "python"] {
+        let candidate = install_dir.join("bin").join(name);
+        if candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+
+    Err(VexError::PythonEnv(format!(
+        "No python binary found in {}",
+        install_dir.join("bin").display()
+    )))
+}

--- a/src/tools/python/tests.rs
+++ b/src/tools/python/tests.rs
@@ -3,6 +3,9 @@ use super::releases::{
     asset_filename, extract_python_version, find_matching_checksum, get_major_minor,
 };
 use super::*;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use tempfile::TempDir;
 
 #[test]
 fn test_name() {
@@ -40,6 +43,57 @@ fn test_bin_paths() {
     assert!(paths.contains(&("pydoc3", "bin")));
     assert!(paths.contains(&("python3-config", "bin")));
     assert_eq!(paths.len(), 8);
+}
+
+#[test]
+fn test_python_does_not_link_dynamic_toolchain_binaries() {
+    assert!(!PythonTool.link_dynamic_binaries());
+}
+
+#[test]
+fn test_base_paths_are_versioned_under_vex_home() {
+    let vex = std::path::Path::new("/tmp/vex-home");
+    assert_eq!(
+        base_env_dir(vex, "3.13.3"),
+        vex.join("python").join("base").join("3.13.3")
+    );
+    assert_eq!(
+        base_bin_dir(vex, "3.13.3"),
+        vex.join("python").join("base").join("3.13.3").join("bin")
+    );
+}
+
+#[test]
+fn test_ensure_base_environment_creates_missing_base() {
+    let temp = TempDir::new().unwrap();
+    let vex = temp.path().join(".vex");
+    let install = temp.path().join("python-3.13.3");
+    let bin = install.join("bin");
+    fs::create_dir_all(&bin).unwrap();
+    let python = bin.join("python3");
+    fs::write(
+        &python,
+        r#"#!/bin/sh
+if [ "$1" = "-m" ] && [ "$2" = "venv" ]; then
+  mkdir -p "$3/bin"
+  printf '#!/bin/sh\n' > "$3/bin/python"
+  printf '#!/bin/sh\n' > "$3/bin/pip"
+  chmod +x "$3/bin/python" "$3/bin/pip"
+  exit 0
+fi
+exit 42
+"#,
+    )
+    .unwrap();
+    let mut perms = fs::metadata(&python).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&python, perms).unwrap();
+
+    let base = ensure_base_environment(&vex, "3.13.3", &install).unwrap();
+    assert_eq!(base, base_env_dir(&vex, "3.13.3"));
+    assert!(base.join("bin/python").exists());
+    assert!(base.join("bin/pip").exists());
+    assert!(is_base_env_healthy(&vex, "3.13.3"));
 }
 
 #[test]

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -1289,6 +1289,60 @@ fn test_python_sync_no_lock() {
 }
 
 #[test]
+fn test_python_base_requires_active_python() {
+    let home = fresh_temp_dir("vex_test_python_base_no_active");
+    let output = vex_bin()
+        .args(["python", "base"])
+        .env("HOME", &home)
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("No active vex-managed Python"));
+
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+#[test]
+fn test_python_base_path_creates_base_env() {
+    let home = fresh_temp_dir("vex_test_python_base_path");
+    let toolchain = home.join(".vex/toolchains/python/3.13.3");
+    let toolchain_bin = toolchain.join("bin");
+    fs::create_dir_all(&toolchain_bin).unwrap();
+    fs::create_dir_all(home.join(".vex/current")).unwrap();
+    write_executable_script(
+        &toolchain_bin.join("python3"),
+        r#"#!/bin/sh
+if [ "$1" = "-m" ] && [ "$2" = "venv" ]; then
+  mkdir -p "$3/bin"
+  printf '#!/bin/sh\n' > "$3/bin/python"
+  printf '#!/bin/sh\n' > "$3/bin/pip"
+  chmod +x "$3/bin/python" "$3/bin/pip"
+  exit 0
+fi
+exit 42
+"#,
+    );
+    std::os::unix::fs::symlink(&toolchain, home.join(".vex/current/python")).unwrap();
+
+    let output = vex_bin()
+        .args(["python", "base", "path"])
+        .env("HOME", &home)
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{:?}", output);
+    let expected_base = home.join(".vex/python/base/3.13.3");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        expected_base.display().to_string()
+    );
+    assert!(expected_base.join("bin/python").exists());
+    assert!(expected_base.join("bin/pip").exists());
+
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+#[test]
 fn test_python_list_installed() {
     let output = vex_bin().args(["list", "python"]).output().unwrap();
     assert!(output.status.success());

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -165,6 +165,49 @@ fn test_current_json() {
 }
 
 #[test]
+fn test_globals_help() {
+    let output = vex_bin().args(["globals", "--help"]).output().unwrap();
+    assert!(output.status.success(), "{:?}", output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("List global CLIs"));
+    assert!(stdout.contains("node, python, go, rust, java, maven, or gradle"));
+}
+
+#[test]
+fn test_globals_json_reports_go_cli_version_source() {
+    let home = fresh_temp_dir("vex_test_globals_go");
+    let vex = home.join(".vex");
+    let go_bin = vex.join("go/bin");
+    let toolchain = vex.join("toolchains/go/1.26.2");
+    fs::create_dir_all(&go_bin).unwrap();
+    fs::create_dir_all(&toolchain).unwrap();
+    fs::create_dir_all(vex.join("current")).unwrap();
+    write_executable_script(&go_bin.join("gopls"), "#!/bin/sh\n");
+    std::os::unix::fs::symlink(&toolchain, vex.join("current/go")).unwrap();
+    fs::write(vex.join("tool-versions"), "go 1.26.2\n").unwrap();
+
+    let output = vex_bin()
+        .args(["globals", "go", "--json"])
+        .env("HOME", &home)
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{:?}", output);
+    let parsed: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let entries = parsed.get("entries").unwrap().as_array().unwrap();
+    let gopls = entries
+        .iter()
+        .find(|entry| entry.get("name").and_then(Value::as_str) == Some("gopls"))
+        .expect("gopls should be reported");
+    assert_eq!(gopls.get("tool").and_then(Value::as_str), Some("go"));
+    assert_eq!(
+        gopls.get("version_source").and_then(Value::as_str),
+        Some("Global default")
+    );
+
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+#[test]
 fn test_env_exports_include_captured_user_state() {
     let home = fresh_temp_dir("vex_test_env_exports_home");
     let project = fresh_temp_dir("vex_test_env_exports_project");
@@ -1047,6 +1090,7 @@ fn test_doctor_json() {
     let parsed: Value = serde_json::from_str(&stdout).unwrap();
     assert!(parsed.get("root").is_some());
     assert!(parsed.get("checks").unwrap().is_array());
+    assert!(parsed.get("global_clis").unwrap().is_array());
 
     let _ = std::fs::remove_dir_all(&home);
 }

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -170,7 +170,15 @@ fn test_globals_help() {
     assert!(output.status.success(), "{:?}", output);
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("List global CLIs"));
-    assert!(stdout.contains("node, python, go, rust, java, maven, or gradle"));
+    assert!(stdout.contains("node, python, go, rust, java, maven, mvn, or gradle"));
+}
+
+#[test]
+fn test_globals_rejects_invalid_filter() {
+    let output = vex_bin().args(["globals", "unknown"]).output().unwrap();
+    assert!(!output.status.success(), "{:?}", output);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("invalid value 'unknown'"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add managed Python base environment workflows so global pip-installed CLIs such as kaggle can be discovered without leaking into project virtualenv activation
- prefer project Node binaries over global npm bins, and add `vex globals` / `doctor` inventory for Python, Node, Go, Rust, Java, Maven, and Gradle
- bump release metadata/docs to v1.7.0 and add local/GitHub smoke coverage for global CLI inventory

## Local validation

- `cargo fmt --all --check`
- `git diff --check`
- `bash scripts/check-docs.sh`
- `bash scripts/check-release-tooling.sh`
- `VEX_BIN="$(pwd)/target/debug/vex" bash scripts/test-management-features.sh`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -- --test-threads=1`
- `cargo audit`
- `cargo deny check advisories`

## Security scan

Codex Security diff scan completed with no reportable findings. Report artifact:
`/tmp/codex-security-scans/vex/941d73d_20260502T161838Z/report.md`

## GitHub gate

Local `cargo test --all-features -- --test-threads=1` reached the Go network e2e and failed because this machine cannot complete TLS to `dl.google.com`. This PR must pass GitHub Actions in the clean runner before merge/release.
