### PR TITLE
Fix versioned Python global symlinks

### DIFF
--- a/src/switcher/links.rs
+++ b/src/switcher/links.rs
@@ -62,7 +62,7 @@ fn update_bin_links(tool: &dyn Tool, base_dir: &Path, toolchain_dir: &Path) -> R
     let bin_paths = tool.bin_paths();
     let mut new_binaries = link_declared_binaries(toolchain_dir, &bin_dir, &bin_paths)?;
     if tool.link_dynamic_binaries() {
-        link_dynamic_binaries(toolchain_dir, &bin_dir, &bin_paths, &mut new_binaries)?;
+        link_dynamic_binaries(tool, toolchain_dir, &bin_dir, &bin_paths, &mut new_binaries)?;
     }
     cleanup_stale_bin_links(tool, &bin_dir, &new_binaries);
 
@@ -92,6 +92,7 @@ fn link_declared_binaries(
 }
 
 fn link_dynamic_binaries(
+    tool: &dyn Tool,
     toolchain_dir: &Path,
     bin_dir: &Path,
     bin_paths: &[(&str, &str)],
@@ -109,6 +110,9 @@ fn link_dynamic_binaries(
                 let filename_str = filename.to_string_lossy();
 
                 if bin_paths.iter().any(|(name, _)| *name == filename_str) {
+                    continue;
+                }
+                if !tool.should_link_dynamic_binary(filename_str.as_ref()) {
                     continue;
                 }
 

--- a/src/switcher/tests.rs
+++ b/src/switcher/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::tools::go::GoTool;
 use crate::tools::node::NodeTool;
+use crate::tools::python::PythonTool;
 use crate::tools::rust::RustTool;
 use crate::tools::{Arch, Tool, Version};
 use std::fs;
@@ -177,6 +178,50 @@ fn test_dynamic_binary_detection() {
     assert!(base.join("bin/node").exists());
     assert!(base.join("bin/npm").exists());
     assert!(base.join("bin/npx").exists());
+
+    let _ = fs::remove_dir_all(&base);
+}
+
+#[test]
+fn test_python_dynamic_versioned_binaries_are_linked_without_internal_alias() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let base = make_temp_dir("python_dynamic_bins");
+    let toolchain = base.join("toolchains/python/3.14.4");
+    let bin = toolchain.join("bin");
+    fs::create_dir_all(&bin).unwrap();
+
+    for name in &[
+        "python",
+        "python3",
+        "pip",
+        "pip3",
+        "idle3.14",
+        "pip3.14",
+        "pydoc3.14",
+        "python3.14",
+        "python3.14-config",
+        "\u{1d70b}thon",
+    ] {
+        let path = bin.join(name);
+        fs::write(&path, "fake").unwrap();
+        let mut perms = fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&path, perms).unwrap();
+    }
+
+    super::links::perform_switch(&PythonTool, &base, &toolchain).unwrap();
+
+    for name in &[
+        "idle3.14",
+        "pip3.14",
+        "pydoc3.14",
+        "python3.14",
+        "python3.14-config",
+    ] {
+        assert!(base.join("bin").join(name).exists());
+    }
+    assert!(!base.join("bin").join("\u{1d70b}thon").exists());
 
     let _ = fs::remove_dir_all(&base);
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -106,6 +106,11 @@ pub trait Tool: Send + Sync {
         true
     }
 
+    /// Return whether an executable discovered by dynamic binary linking should be exposed.
+    fn should_link_dynamic_binary(&self, _name: &str) -> bool {
+        true
+    }
+
     /// Return managed user-state directories and environment variables for this tool.
     fn managed_environment(&self, _vex_dir: &Path, _install_dir: Option<&Path>) -> ToolEnvironment {
         ToolEnvironment::default()

--- a/src/tools/python.rs
+++ b/src/tools/python.rs
@@ -138,7 +138,11 @@ impl Tool for PythonTool {
     }
 
     fn link_dynamic_binaries(&self) -> bool {
-        false
+        true
+    }
+
+    fn should_link_dynamic_binary(&self, name: &str) -> bool {
+        name != "\u{1d70b}thon"
     }
 
     fn managed_environment(

--- a/src/tools/python/tests.rs
+++ b/src/tools/python/tests.rs
@@ -46,8 +46,11 @@ fn test_bin_paths() {
 }
 
 #[test]
-fn test_python_does_not_link_dynamic_toolchain_binaries() {
-    assert!(!PythonTool.link_dynamic_binaries());
+fn test_python_links_dynamic_toolchain_binaries_except_internal_alias() {
+    assert!(PythonTool.link_dynamic_binaries());
+    assert!(PythonTool.should_link_dynamic_binary("python3.14"));
+    assert!(PythonTool.should_link_dynamic_binary("pip3.14"));
+    assert!(!PythonTool.should_link_dynamic_binary("\u{1d70b}thon"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- expose Python versioned executables such as `python3.14`, `pip3.14`, `pydoc3.14`, and `idle3.14` in `~/.vex/bin`
- keep python-build-standalone's internal `𝜋thon` alias hidden from global linking
- add unit coverage for Python dynamic binary linking and the internal alias filter

## Validation

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test python_dynamic_versioned -- --test-threads=1`
- `cargo test python_links_dynamic -- --test-threads=1`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -- --test-threads=1`

## Context

This fixes the post-merge Strict macOS failure on main where the fresh Python install expected versioned Python binaries in `~/.vex/bin`.
