### PR TITLE
[codex] improve maintenance recovery flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Managed shell removal** - Added `vex uninit` to remove the vex-managed shell hook block created by `vex init --shell`, including legacy unmarked hook lines.
+- **Doctor auto-repair mode** - Added `vex doctor --repair` to delete dangling symlinks under `~/.vex/current` and `~/.vex/bin` before re-running health checks.
+- **Archive cache size guard** - The reusable archive cache now prunes oldest cached archives beyond a 5 GB cap while keeping the newest archive available for offline reuse.
+- **Rust toolchain TOML discovery** - Rust version resolution now supports `rust-toolchain`, `.rust-toolchain.toml`, and `rust-toolchain.toml` in addition to `.rust-toolchain`.
+
+### Changed
+
+- **Java and Python activation is stricter** - Java activation now isolates Maven/Gradle state under `~/.vex` and neutralizes global JVM option variables; Python activation clears `PYTHONPATH` and sets `PYTHONNOUSERSITE=1`.
+- **Uninstall cleans vex-owned references** - `vex uninstall <tool@version>` now removes matching global aliases and global `~/.vex/tool-versions` pins while warning, not editing, project-owned `.tool-versions` files.
+
 ## [1.7.0] - 2026-05-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 - **Python base + venv integration** — managed per-version base environments for global Python CLIs, plus `vex python init/freeze/sync` for project `.venv` isolation
 - **Python stable latest behavior** — `vex list-remote python --filter latest` prefers bugfix/security releases over feature or prerelease assets
 - **Shell auto-configuration** — `vex init --shell auto` detects and configures your shell automatically (zsh, bash, fish, nushell)
+- **Managed shell removal** — `vex uninit --shell auto` removes the vex-managed hook block when you want to disable auto-switching cleanly
 - **Project templates** — `vex init --list-templates` and `vex init --template <name>` bootstrap official starters for Node, Go, Java, Rust, and Python
 - **Safe add-only templating** — `vex init --template <name> --add-only` only merges `.tool-versions` and `.gitignore`, then creates missing starter files
 - **Fuzzy version matching** — `node@20` resolves to latest 20.x, `node@lts` to latest LTS
@@ -57,10 +58,11 @@
 - **Team config sync** — `vex install --from` / `vex sync --from` support local files, `vex-config.toml`, HTTPS team configs, and Git repositories with a safe `[tools]` schema
 - **Shared npm globals** — Shell hooks and `vex exec`/`run` export `NPM_CONFIG_PREFIX=$HOME/.vex/npm/prefix` and `NPM_CONFIG_USERCONFIG=$HOME/.vex/npm/npmrc`, keep `~/.vex/npm/prefix/bin` on PATH, and use that as a shared user-level npm CLI pool across vex-managed Node versions
 - **Global CLI inventory** — `vex globals` shows shared npm globals, Python base/user-base CLIs, Go `GOBIN`, Cargo-installed tools, and Maven/Gradle build-tool state with version-source hints
-- **Auto-export env vars** — Automatic `JAVA_HOME`, `GOROOT`, `GOENV`, `CARGO_HOME`, captured user-state env vars, Python base/user CLI paths, and project `.venv` activation in shell hooks
+- **Auto-export env vars** — Automatic `JAVA_HOME`, `GOROOT`, `GOENV`, `CARGO_HOME`, Java Maven/Gradle state, Python isolation vars, captured user-state env vars, Python base/user CLI paths, and project `.venv` activation in shell hooks
 - **Official Rust extensions** — `vex rust target/component` manages official Rust toolchain extensions such as `rust-src` and iOS std targets
 - **Contained user-state capture** — supported language homes, caches, and user bins default into `~/.vex`
 - **Explicit home repair** — `vex repair migrate-home` previews and applies safe migrations from legacy home-directory paths
+- **Doctor repair mode** — `vex doctor --repair` removes dangling vex symlinks before re-running health checks
 - **One-command upgrade** — `vex upgrade node` installs and switches to the latest version
 - **Managed context upgrades** — `vex outdated` inspects the current project/global/active scope, and `vex upgrade --all` upgrades that whole managed set
 - **Explicit relink for Node toolchain bins** — `vex relink node` rebuilds `~/.vex/bin` when executables appear inside the active Node toolchain
@@ -73,6 +75,7 @@
 - **Remote version cache** — cached for 5 min by default, configurable via `config.toml`
 - **Concurrent install protection** — file-based locking prevents parallel install corruption
 - **Checksum verification** — SHA-256 verification on all 5 tools (Node.js, Go, Java, Rust, Python) before extraction; install refuses to proceed if upstream checksum fetch fails
+- **Bounded archive cache** — reusable install archives are capped at 5 GB and pruned oldest-first while keeping the newest download available
 - **Parallel downloads** — atomic writes with automatic cleanup, up to 3 concurrent downloads
 - **Parallel extraction** — fast archive extraction using parallel file processing
 - **Security hardening** — TOCTOU protection, ownership validation, path traversal protection, atomic operations
@@ -222,6 +225,9 @@ vex run test
 # Rebuild Node binary links after toolchain executables change
 vex relink node
 
+# Remove the managed shell hook
+vex uninit --shell auto
+
 # Preview or apply safe home-directory migrations into ~/.vex
 vex repair migrate-home
 vex repair migrate-home --apply
@@ -250,6 +256,7 @@ For the full CLI reference, including command groups and option details, see [do
 | `vex init` | Initialize directory structure | `vex init` |
 | `vex init --shell auto` | Initialize and auto-configure shell | `vex init --shell auto` |
 | `vex init --shell zsh` | Initialize and configure specific shell | `vex init --shell zsh` |
+| `vex uninit --shell auto` | Remove the managed shell hook from your shell config | `vex uninit --shell auto` |
 | `vex init --list-templates` | List built-in project templates | `vex init --list-templates` |
 | `vex init --template <name>` | Bootstrap a project starter | `vex init --template rust-cli` |
 | `vex init --template <name> --add-only` | Safely merge missing template files into an existing repo | `vex init --template python-venv --add-only` |
@@ -296,6 +303,7 @@ For the full CLI reference, including command groups and option details, see [do
 | `vex doctor` | Run health check and diagnostics | `vex doctor` |
 | `vex doctor --json` | Run health check and emit JSON | `vex doctor --json` |
 | `vex doctor --verbose` | Show extra provenance and captured-env details | `vex doctor --verbose` |
+| `vex doctor --repair` | Remove dangling vex symlinks, then run diagnostics | `vex doctor --repair` |
 | `vex repair migrate-home` | Preview or apply safe legacy home-directory migrations into `~/.vex` | `vex repair migrate-home --apply` |
 | `vex self-update` | Update vex itself to the latest release | `vex self-update` |
 | `vex env <shell>` | Output shell hook script | `vex env zsh` |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -57,8 +57,11 @@ vex 是一个 macOS 原生的多语言版本管理器。它用直接符号链接
 - **全局 CLI 清单**：`vex globals` 显示 shared npm globals、Python base/user、Go、Cargo、Maven、Gradle 来源和状态。
 - **稳定 Python latest**：`vex list-remote python --filter latest` 优先 bugfix/security 版本，避免把 feature/prerelease 当默认 latest。
 - **自动 shell 集成**：支持 zsh、bash、fish、nushell。
+- **可逆 shell 集成**：`vex uninit --shell auto` 可以移除 `vex init --shell` 写入的托管 hook。
 - **项目模板**：`vex init --template python-venv --add-only` 可安全补齐项目模板文件。
 - **锁文件和离线模式**：`.tool-versions.lock`、`--frozen`、`--offline` 支持可复现和缓存优先的安装。
+- **诊断修复模式**：`vex doctor --repair` 会先清理 `~/.vex/current` 和 `~/.vex/bin` 里的悬空符号链接，再运行诊断。
+- **有上限的 archive cache**：下载归档缓存默认 5 GB，超过后按最旧优先清理，并保留最新下载。
 - **发布验证**：CI 覆盖 Rustfmt、Clippy、三平台测试、安全审计、macOS feature smoke、Strict macOS、发布 postflight。
 
 ## 快速开始
@@ -211,6 +214,12 @@ vex install
 ```
 
 启用 shell hook 后，进入项目目录会自动执行 `vex use --auto`。
+
+如果要移除托管 hook：
+
+```bash
+vex uninit --shell auto
+```
 
 ## GitHub Actions
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -88,6 +88,9 @@ Found a typo or want to improve the docs? Contributions are welcome!
 
 Recent user-facing additions that should stay in sync across these docs:
 
+- `vex uninit --shell` for removing managed shell hook blocks
+- `vex doctor --repair` for deleting dangling vex symlinks before diagnostics
+- archive cache size pruning and offline-cache checksum expectations
 - `vex init --template`, `--list-templates`, and `--add-only`
 - shared npm globals in `~/.vex/npm/prefix` plus the `NPM_CONFIG_PREFIX` / `NPM_CONFIG_USERCONFIG` shell/export behavior
 - `vex globals` for inspecting npm, Python base/user, Go, Cargo, Maven, and Gradle global CLI/build-tool state

--- a/docs/guides/best-practices.md
+++ b/docs/guides/best-practices.md
@@ -221,11 +221,20 @@ Use `vex globals --verbose` when debugging command resolution. It shows the glob
 
 ## Java Build Tools
 
-`vex` manages the active JDK and `JAVA_HOME`; Maven and Gradle remain project or system tools. Prefer `mvnw` and `gradlew` inside projects so the build tool version is pinned with the repository.
+`vex` manages the active JDK and `JAVA_HOME`. When user-state capture is enabled,
+it also points Maven's local repository and Gradle's user home into `~/.vex` and
+neutralizes global JVM option variables such as `JAVA_TOOL_OPTIONS`.
+
+Maven and Gradle themselves remain project or system tools. Prefer `mvnw` and
+`gradlew` inside projects so the build tool version is pinned with the repository.
 
 `vex globals java` and `vex doctor` report external `mvn`/`gradle` binaries plus `~/.m2` and `~/.gradle` state so you can see when Java build-tool state lives outside `~/.vex`.
 
 ## Rust Projects
+
+`vex` resolves Rust pins from `.tool-versions`, `.rust-toolchain`,
+`rust-toolchain`, `.rust-toolchain.toml`, and `rust-toolchain.toml`. For TOML
+files, it reads `[toolchain].channel`, matching rustup's common project format.
 
 For Rust projects that need official extensions, keep them in `vex` instead of falling back to a second toolchain manager:
 

--- a/docs/guides/command-reference.md
+++ b/docs/guides/command-reference.md
@@ -18,6 +18,7 @@ Use it when you want the full command map in one place without jumping between R
 
 ```text
 vex init
+vex uninit
 vex install
 vex sync
 vex use
@@ -83,6 +84,31 @@ vex init --template rust-cli
 vex init --template python-venv --add-only
 ```
 
+### `vex uninit`
+
+Remove the vex-managed shell hook block from your shell config.
+
+Usage:
+
+```bash
+vex uninit
+vex uninit --shell <shell>
+vex uninit --shell <shell> --dry-run
+```
+
+Options:
+
+- `--shell <shell>`
+  - valid values: `auto`, `zsh`, `bash`, `fish`, `nu`
+- `--dry-run`
+  - preview the shell config that would be cleaned
+
+Notes:
+
+- `vex uninit` removes the marker block written by current `vex init --shell` runs.
+- It also removes legacy unmarked hook snippets from older installs.
+- It does not delete `~/.vex`, installed toolchains, version files, or project configuration.
+
 ### `vex env`
 
 Print the generated shell hook for auto-switching.
@@ -124,6 +150,7 @@ Usage:
 vex doctor
 vex doctor --json
 vex doctor --verbose
+vex doctor --repair
 ```
 
 Options:
@@ -132,6 +159,8 @@ Options:
   - print machine-readable diagnostics
 - `--verbose`
   - include extra provenance and captured-environment details in text output
+- `--repair`
+  - delete dangling symlinks under `~/.vex/current` and `~/.vex/bin`, then run diagnostics
 
 ### `vex globals`
 
@@ -318,6 +347,10 @@ Example:
 vex local node@20.11.0
 ```
 
+Version discovery also understands common language-specific files. Rust projects can
+use `.rust-toolchain`, `rust-toolchain`, `.rust-toolchain.toml`, or
+`rust-toolchain.toml`; TOML files read `[toolchain].channel`.
+
 ### `vex global`
 
 Write a global default version into `~/.vex/tool-versions`.
@@ -349,6 +382,12 @@ Example:
 ```bash
 vex uninstall node@20.11.0
 ```
+
+Notes:
+
+- matching global aliases in `~/.vex/aliases.toml` are removed automatically
+- matching global pins in `~/.vex/tool-versions` are removed automatically
+- project `.tool-versions` files are not edited; vex warns if the current project still pins the removed version
 
 ## Rust Extensions
 

--- a/docs/guides/shell-integration.md
+++ b/docs/guides/shell-integration.md
@@ -141,6 +141,25 @@ vex env fish --exports
 vex env nu --exports
 ```
 
+## Removing Shell Integration
+
+Use `vex uninit` when you want to remove the managed hook that `vex init --shell`
+added to your shell config:
+
+```bash
+vex uninit --shell auto
+```
+
+Preview first with:
+
+```bash
+vex uninit --shell zsh --dry-run
+```
+
+`vex uninit` removes only the managed vex hook block or older legacy vex hook
+snippet. It leaves `~/.vex`, installed toolchains, version files, and project
+configuration untouched.
+
 ## Verifying Shell Integration
 
 ### Check if hook is installed

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -207,22 +207,49 @@ find ~/.vex -type l ! -exec test -e {} \; -print
 
 **Solutions**:
 
-1. **Remove broken symlinks**:
+1. **Use doctor repair mode**:
+   ```bash
+   vex doctor --repair
+   ```
+
+2. **Remove broken symlinks manually**:
    ```bash
    find ~/.vex/bin -type l ! -exec test -e {} \; -delete
    find ~/.vex/current -type l ! -exec test -e {} \; -delete
    ```
 
-2. **If the broken link points into the active Node toolchain, rebuild Node links explicitly**:
+3. **If the broken link points into the active Node toolchain, rebuild Node links explicitly**:
    ```bash
    vex relink node
    ```
 
-3. **Reinstall version**:
+4. **Reinstall version**:
    ```bash
    vex uninstall node@20.11.0
    vex install node@20.11.0
    ```
+
+#### Remove vex shell integration
+
+**Symptoms**:
+
+- you want to stop automatic version switching
+- an old shell config still contains a vex hook
+- `vex doctor` reports duplicate shell hooks
+
+**Solution**:
+
+```bash
+vex uninit --shell auto
+```
+
+Use `--dry-run` to preview the target config file without editing it:
+
+```bash
+vex uninit --shell zsh --dry-run
+```
+
+This removes only the vex-managed hook block or legacy vex hook snippet. It does not delete `~/.vex` or installed toolchains.
 
 #### npm install -g succeeded but command is still not found
 

--- a/docs/reliability.md
+++ b/docs/reliability.md
@@ -59,6 +59,16 @@ change and is intentionally not exposed.
 
 Implementation: `src/installer/offline.rs`.
 
+### Archive cache bounds
+
+Reusable install archives live under `~/.vex/cache/archives/`. After storing a
+new archive, vex enforces a 5 GB default cap and evicts the oldest cached archives
+by modification time. The newest archive is kept even if it alone exceeds the cap,
+so a successful download remains usable for immediate retry or offline install.
+
+When an archive is evicted, its `.sha256` sidecar is removed with it. Offline mode
+still requires both the archive and checksum sidecar to be present.
+
 ## 4. CleanupGuard (RAII for temp files)
 
 Every install / extract path constructs a `CleanupGuard` that owns the list of
@@ -150,6 +160,7 @@ on next run cleans it up before retrying.
 | Checksum mismatch | Discard archive; `VexError::ChecksumMismatch` | `src/checksum.rs` |
 | Checksum source unreachable | Refuse install | `src/installer/online.rs:91-95` |
 | Cached archive corrupted | Invalidate cache; re-download (or fail in offline mode) | `src/archive_cache.rs` |
+| Archive cache exceeds 5 GB | Evict oldest archives and their checksum sidecars, keeping the newest archive | `src/archive_cache.rs` |
 | `--offline` cache miss | `VexError::OfflineModeError`; no network fallback | `src/installer/offline.rs` |
 | Panic / SIGTERM mid-extract | `CleanupGuard` removes temp paths | `src/installer/support.rs` |
 | Concurrent same-version install | File lock serializes; PID-based stale-lock recovery | `src/lock.rs` |

--- a/src/activation/env/managed.rs
+++ b/src/activation/env/managed.rs
@@ -1,4 +1,4 @@
-use super::{checked_install_dir, ALWAYS_MANAGED_ENV_KEYS, SUPPORTED_TOOLS};
+use super::{checked_install_dir, ALWAYS_MANAGED_ENV_KEYS, ALWAYS_UNSET_ENV_KEYS, SUPPORTED_TOOLS};
 use crate::error::Result;
 use crate::tools;
 use std::collections::{BTreeMap, BTreeSet};
@@ -38,7 +38,9 @@ pub(in crate::activation) fn build_unset_env(
     for tool_name in versions.keys() {
         let tool = tools::get_tool(tool_name)?;
         for key in tool.managed_env_keys() {
-            if capture_user_state || ALWAYS_MANAGED_ENV_KEYS.contains(&key) {
+            if (capture_user_state || ALWAYS_MANAGED_ENV_KEYS.contains(&key))
+                && !ALWAYS_UNSET_ENV_KEYS.contains(&key)
+            {
                 active_keys.insert(key.to_string());
             }
         }
@@ -75,6 +77,9 @@ fn filter_managed_env(
 ) -> BTreeMap<String, String> {
     managed_env
         .into_iter()
-        .filter(|(key, _)| capture_user_state || ALWAYS_MANAGED_ENV_KEYS.contains(&key.as_str()))
+        .filter(|(key, _)| {
+            (capture_user_state || ALWAYS_MANAGED_ENV_KEYS.contains(&key.as_str()))
+                && !ALWAYS_UNSET_ENV_KEYS.contains(&key.as_str())
+        })
         .collect()
 }

--- a/src/activation/env/mod.rs
+++ b/src/activation/env/mod.rs
@@ -24,7 +24,16 @@ pub(super) use shell_state::{
 
 pub(in crate::activation) const SUPPORTED_TOOLS: &[&str] =
     &["go", "java", "node", "python", "rust"];
-pub(in crate::activation) const ALWAYS_MANAGED_ENV_KEYS: &[&str] = &["GOROOT", "JAVA_HOME"];
+pub(in crate::activation) const ALWAYS_MANAGED_ENV_KEYS: &[&str] = &[
+    "GOROOT",
+    "JAVA_HOME",
+    // Hostile-host env vars vex must always neutralize when the tool is active.
+    "JAVA_TOOL_OPTIONS",
+    "_JAVA_OPTIONS",
+    "PYTHONPATH",
+];
+pub(in crate::activation) const ALWAYS_UNSET_ENV_KEYS: &[&str] =
+    &["JAVA_TOOL_OPTIONS", "_JAVA_OPTIONS", "PYTHONPATH"];
 
 #[derive(Debug, Clone)]
 pub(in crate::activation) struct ShellProjectEnv {

--- a/src/activation/tests.rs
+++ b/src/activation/tests.rs
@@ -84,6 +84,26 @@ fn test_activation_plan_uses_python_base_without_project_venv() {
             plan.set_env.get("PYTHONUSERBASE").cloned(),
             Some(vex_dir.join("python/user").display().to_string())
         );
+        assert!(!plan.set_env.contains_key("PYTHONPATH"));
+        assert!(plan.unset_env.contains(&"PYTHONPATH".to_string()));
+    });
+}
+
+#[test]
+fn test_activation_plan_unsets_hostile_java_env_vars() {
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    let vex_dir = home.path().join(".vex");
+    fs::create_dir_all(vex_dir.join("toolchains/java/25")).unwrap();
+    fs::write(project.path().join(".tool-versions"), "java 25\n").unwrap();
+
+    with_home(home.path(), || {
+        let plan = build_activation_plan(project.path()).unwrap();
+
+        assert!(!plan.set_env.contains_key("JAVA_TOOL_OPTIONS"));
+        assert!(!plan.set_env.contains_key("_JAVA_OPTIONS"));
+        assert!(plan.unset_env.contains(&"JAVA_TOOL_OPTIONS".to_string()));
+        assert!(plan.unset_env.contains(&"_JAVA_OPTIONS".to_string()));
     });
 }
 

--- a/src/alias.rs
+++ b/src/alias.rs
@@ -142,4 +142,29 @@ impl AliasManager {
         let global = self.load_global()?;
         Ok(global.tools.get(tool).and_then(|a| a.get(alias)).cloned())
     }
+
+    /// Remove every global alias that points at `tool@version`.
+    /// Returns the alias names that were deleted.
+    pub fn prune_global_for_version(&self, tool: &str, version: &str) -> Result<Vec<String>> {
+        let mut config = self.load_global()?;
+        let Some(aliases) = config.tools.get_mut(tool) else {
+            return Ok(Vec::new());
+        };
+
+        let removed: Vec<String> = aliases
+            .iter()
+            .filter(|(_, v)| v.as_str() == version)
+            .map(|(name, _)| name.clone())
+            .collect();
+        for name in &removed {
+            aliases.remove(name);
+        }
+        if aliases.is_empty() {
+            config.tools.remove(tool);
+        }
+        if !removed.is_empty() {
+            self.save_global(&config)?;
+        }
+        Ok(removed)
+    }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -18,6 +18,7 @@ fn dispatch(command: Commands) -> Result<()> {
             args.dry_run,
             args.add_only,
         )?,
+        Commands::Uninit(args) => commands::init::run_uninit(args.shell.as_deref(), args.dry_run)?,
         Commands::Install(args) => {
             if !args.specs.is_empty() {
                 commands::toolchain::install_specs(
@@ -127,7 +128,11 @@ fn dispatch(command: Commands) -> Result<()> {
             exit_on_failure(commands::process::run_task(&args.task, &args.args)?)
         }
         Commands::Doctor(args) => {
-            commands::doctor::run(output::OutputMode::from_json_flag(args.json), args.verbose)?;
+            commands::doctor::run_with_repair(
+                output::OutputMode::from_json_flag(args.json),
+                args.verbose,
+                args.repair,
+            )?;
         }
         Commands::Repair(args) => commands::repair::run(&args)?,
         Commands::SelfUpdate => {

--- a/src/archive_cache.rs
+++ b/src/archive_cache.rs
@@ -7,15 +7,20 @@ use crate::checksum;
 use crate::error::Result;
 use std::fs;
 use std::path::{Path, PathBuf};
-use tracing::{debug, info};
+use std::time::SystemTime;
+use tracing::{debug, info, warn};
 #[cfg(test)]
 mod tests;
+
+/// Default archive cache size cap. Beyond this, oldest archives are evicted (LRU by mtime).
+pub const DEFAULT_CACHE_SIZE_LIMIT_BYTES: u64 = 5 * 1024 * 1024 * 1024; // 5 GB
 
 /// Archive cache manager
 ///
 /// Stores downloaded archives in `~/.vex/cache/archives/<tool>/<version>/<filename>`
 pub struct ArchiveCache {
     cache_dir: PathBuf,
+    size_limit_bytes: u64,
 }
 
 impl ArchiveCache {
@@ -24,8 +29,14 @@ impl ArchiveCache {
     /// # Arguments
     /// - `vex_dir` - vex root directory (`~/.vex`)
     pub fn new(vex_dir: &Path) -> Self {
+        Self::with_size_limit(vex_dir, DEFAULT_CACHE_SIZE_LIMIT_BYTES)
+    }
+
+    /// Create archive cache manager with a custom byte size cap.
+    pub fn with_size_limit(vex_dir: &Path, size_limit_bytes: u64) -> Self {
         Self {
             cache_dir: vex_dir.join("cache").join("archives"),
+            size_limit_bytes,
         }
     }
 
@@ -84,7 +95,63 @@ impl ArchiveCache {
             dest_path.display()
         );
 
+        if let Err(err) = self.enforce_size_limit() {
+            warn!("Archive cache eviction failed: {}", err);
+        }
+
         Ok(dest_path)
+    }
+
+    /// Evict oldest cached archives (by mtime) until total size is under the cap.
+    /// Keeps the just-stored archive even if it alone exceeds the cap.
+    pub fn enforce_size_limit(&self) -> Result<u64> {
+        if self.size_limit_bytes == 0 || !self.cache_dir.exists() {
+            return Ok(0);
+        }
+
+        let mut entries = collect_cached_files(&self.cache_dir)?;
+        let total: u64 = entries.iter().map(|e| e.size).sum();
+        if total <= self.size_limit_bytes {
+            return Ok(0);
+        }
+
+        // Oldest first, but keep the newest archive. If the newest archive alone
+        // exceeds the cap, keeping it is better than deleting the file we just
+        // downloaded and forcing the next install to download it again.
+        entries.sort_by_key(|e| e.mtime);
+
+        let mut evicted_bytes: u64 = 0;
+        let mut running = total;
+        let keep_index = entries.len().saturating_sub(1);
+        for (idx, entry) in entries.into_iter().enumerate() {
+            if running <= self.size_limit_bytes {
+                break;
+            }
+            if idx == keep_index {
+                break;
+            }
+            if remove_cached_archive(&entry.path).is_ok() {
+                evicted_bytes = evicted_bytes.saturating_add(entry.size);
+                running = running.saturating_sub(entry.size);
+                debug!("Evicted cache archive: {}", entry.path.display());
+
+                // Clean up empty per-version dirs to keep the layout tidy.
+                if let Some(parent) = entry.path.parent() {
+                    let _ = remove_dir_if_empty(parent);
+                    if let Some(grandparent) = parent.parent() {
+                        let _ = remove_dir_if_empty(grandparent);
+                    }
+                }
+            }
+        }
+
+        if evicted_bytes > 0 {
+            info!(
+                "Pruned {} bytes from archive cache (cap {} bytes)",
+                evicted_bytes, self.size_limit_bytes
+            );
+        }
+        Ok(evicted_bytes)
     }
 
     /// Store verified archive checksum next to the cached archive.
@@ -135,6 +202,18 @@ impl ArchiveCache {
         Ok(())
     }
 
+    /// Total bytes currently held by the archive cache.
+    #[cfg(test)]
+    pub fn total_size_bytes(&self) -> Result<u64> {
+        if !self.cache_dir.exists() {
+            return Ok(0);
+        }
+        Ok(collect_cached_files(&self.cache_dir)?
+            .iter()
+            .map(|e| e.size)
+            .sum())
+    }
+
     /// List all cached versions for a tool
     #[cfg(test)]
     pub fn list_cached_versions(&self, tool_name: &str) -> Result<Vec<String>> {
@@ -155,4 +234,64 @@ impl ArchiveCache {
 
         Ok(versions)
     }
+}
+
+struct CachedFile {
+    path: PathBuf,
+    size: u64,
+    mtime: SystemTime,
+}
+
+fn collect_cached_files(root: &Path) -> Result<Vec<CachedFile>> {
+    let mut out = Vec::new();
+    walk_cache_files(root, &mut out)?;
+    Ok(out)
+}
+
+fn walk_cache_files(dir: &Path, out: &mut Vec<CachedFile>) -> Result<()> {
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            walk_cache_files(&entry.path(), out)?;
+        } else if file_type.is_file() {
+            // Ignore companion checksum files when computing the cache footprint —
+            // they're tiny and we evict them implicitly when the archive goes.
+            let path = entry.path();
+            if path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .map(|name| name.ends_with(".sha256"))
+                .unwrap_or(false)
+            {
+                continue;
+            }
+            let meta = entry.metadata()?;
+            let size = meta.len();
+            let mtime = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+            out.push(CachedFile { path, size, mtime });
+        }
+    }
+    Ok(())
+}
+
+fn remove_dir_if_empty(path: &Path) -> std::io::Result<()> {
+    if path.is_dir() && fs::read_dir(path)?.next().is_none() {
+        fs::remove_dir(path)?;
+    }
+    Ok(())
+}
+
+fn remove_cached_archive(path: &Path) -> std::io::Result<()> {
+    fs::remove_file(path)?;
+    let checksum_path = path.with_file_name(format!(
+        "{}.sha256",
+        path.file_name()
+            .map(|name| name.to_string_lossy())
+            .unwrap_or_default()
+    ));
+    if checksum_path.exists() {
+        fs::remove_file(checksum_path)?;
+    }
+    Ok(())
 }

--- a/src/archive_cache/tests.rs
+++ b/src/archive_cache/tests.rs
@@ -114,6 +114,84 @@ fn test_verify_checksum_success() {
 }
 
 #[test]
+fn test_enforce_size_limit_evicts_oldest() {
+    let tmp = TempDir::new().unwrap();
+    let cache = ArchiveCache::with_size_limit(tmp.path(), 100);
+
+    let make_archive = |name: &str, bytes: usize| {
+        let p = tmp.path().join(name);
+        fs::write(&p, vec![0u8; bytes]).unwrap();
+        p
+    };
+
+    // Older, larger archive.
+    let old = make_archive("old.tar.gz", 80);
+    cache
+        .store_archive("node", "18.0.0", "node-v18.0.0.tar.gz", &old)
+        .unwrap();
+
+    // Make sure the second file's mtime is strictly newer.
+    std::thread::sleep(std::time::Duration::from_millis(20));
+
+    let new = make_archive("new.tar.gz", 60);
+    cache
+        .store_archive("node", "20.0.0", "node-v20.0.0.tar.gz", &new)
+        .unwrap();
+
+    // Combined would be 140 > 100, so the older one should have been evicted.
+    assert!(!cache.has_archive("node", "18.0.0", "node-v18.0.0.tar.gz"));
+    assert!(cache.has_archive("node", "20.0.0", "node-v20.0.0.tar.gz"));
+    assert!(cache.total_size_bytes().unwrap() <= 100);
+}
+
+#[test]
+fn test_enforce_size_limit_keeps_newest_when_it_exceeds_limit() {
+    let tmp = TempDir::new().unwrap();
+    let cache = ArchiveCache::with_size_limit(tmp.path(), 50);
+
+    let test_file = tmp.path().join("large.tar.gz");
+    fs::write(&test_file, vec![0u8; 80]).unwrap();
+
+    cache
+        .store_archive("node", "24.0.0", "node-v24.0.0.tar.gz", &test_file)
+        .unwrap();
+
+    assert!(cache.has_archive("node", "24.0.0", "node-v24.0.0.tar.gz"));
+    assert_eq!(cache.total_size_bytes().unwrap(), 80);
+}
+
+#[test]
+fn test_enforce_size_limit_removes_checksum_with_evicted_archive() {
+    let tmp = TempDir::new().unwrap();
+    let cache = ArchiveCache::with_size_limit(tmp.path(), 100);
+
+    let old = tmp.path().join("old.tar.gz");
+    fs::write(&old, vec![0u8; 80]).unwrap();
+    cache
+        .store_archive("node", "18.0.0", "node-v18.0.0.tar.gz", &old)
+        .unwrap();
+    cache
+        .store_archive_checksum("node", "18.0.0", "node-v18.0.0.tar.gz", "abc123")
+        .unwrap();
+
+    std::thread::sleep(std::time::Duration::from_millis(20));
+
+    let new = tmp.path().join("new.tar.gz");
+    fs::write(&new, vec![0u8; 60]).unwrap();
+    cache
+        .store_archive("node", "20.0.0", "node-v20.0.0.tar.gz", &new)
+        .unwrap();
+
+    assert!(!cache.has_archive("node", "18.0.0", "node-v18.0.0.tar.gz"));
+    assert_eq!(
+        cache
+            .get_archive_checksum("node", "18.0.0", "node-v18.0.0.tar.gz")
+            .unwrap(),
+        None
+    );
+}
+
+#[test]
 fn test_verify_checksum_failure() {
     let tmp = TempDir::new().unwrap();
     let cache = ArchiveCache::new(tmp.path());

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,6 +26,9 @@ pub(crate) enum Commands {
     /// Initialize vex directory structure
     Init(init::InitArgs),
 
+    /// Remove the vex shell hook from your shell config (inverse of `vex init --shell`)
+    Uninit(init::UninitArgs),
+
     /// Install a tool version (or all from .tool-versions)
     Install(toolchain::InstallArgs),
 

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -22,3 +22,14 @@ pub(crate) struct InitArgs {
     #[arg(long, requires = "template", conflicts_with_all = ["shell", "list_templates"])]
     pub(crate) add_only: bool,
 }
+
+#[derive(Args)]
+pub(crate) struct UninitArgs {
+    /// Shell to clean (auto, zsh, bash, fish, or nu)
+    #[arg(long)]
+    pub(crate) shell: Option<String>,
+
+    /// Preview changes without modifying files
+    #[arg(long)]
+    pub(crate) dry_run: bool,
+}

--- a/src/cli/manage.rs
+++ b/src/cli/manage.rs
@@ -42,6 +42,10 @@ pub(crate) struct DoctorArgs {
     /// Show extended metadata and audit details
     #[arg(long)]
     pub(crate) verbose: bool,
+
+    /// Attempt to auto-fix safe issues (e.g. delete dangling symlinks under ~/.vex/bin)
+    #[arg(long)]
+    pub(crate) repair: bool,
 }
 
 #[derive(Args)]

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -2,12 +2,35 @@ mod checks;
 mod render;
 mod types;
 
-use crate::error::Result;
+use crate::config;
+use crate::error::{Result, VexError};
 use crate::output::{print_json, OutputMode};
+use owo_colors::OwoColorize;
 
 pub use types::{CheckStatus, DoctorReport};
 
-pub fn run(output: OutputMode, verbose: bool) -> Result<()> {
+pub fn run_with_repair(output: OutputMode, verbose: bool, repair: bool) -> Result<()> {
+    if repair {
+        let vex_dir = config::vex_home().ok_or(VexError::HomeDirectoryNotFound)?;
+        let removed = checks::repair_broken_links(&vex_dir);
+        if matches!(output, OutputMode::Text) {
+            if removed.is_empty() {
+                println!("{} no dangling symlinks to repair", "✓".green());
+            } else {
+                println!(
+                    "{} Removed {} dangling symlink{}:",
+                    "✓".green(),
+                    removed.len(),
+                    if removed.len() == 1 { "" } else { "s" }
+                );
+                for label in &removed {
+                    println!("  - {}", label);
+                }
+                println!();
+            }
+        }
+    }
+
     let report = collect()?;
     match output {
         OutputMode::Json => print_json(&report),

--- a/src/commands/doctor/checks.rs
+++ b/src/commands/doctor/checks.rs
@@ -10,6 +10,11 @@ use crate::config;
 use crate::error::{Result, VexError};
 use crate::resolver;
 use crate::version_state;
+use std::path::Path;
+
+pub(crate) fn repair_broken_links(vex_dir: &Path) -> Vec<String> {
+    system::repair_broken_links(vex_dir)
+}
 
 pub(super) fn collect() -> Result<DoctorReport> {
     let vex_dir = config::vex_home().ok_or(VexError::HomeDirectoryNotFound)?;

--- a/src/commands/doctor/checks/system.rs
+++ b/src/commands/doctor/checks/system.rs
@@ -41,6 +41,10 @@ pub(super) fn collect_broken_links(vex_dir: &Path) -> (Vec<String>, bool) {
     filesystem::collect_broken_links(vex_dir)
 }
 
+pub(crate) fn repair_broken_links(vex_dir: &Path) -> Vec<String> {
+    filesystem::repair_broken_links(vex_dir)
+}
+
 pub(super) fn collect_failed_binaries(bin_dir: &Path) -> Vec<String> {
     filesystem::collect_failed_binaries(bin_dir)
 }

--- a/src/commands/doctor/checks/system/filesystem.rs
+++ b/src/commands/doctor/checks/system/filesystem.rs
@@ -9,6 +9,10 @@ pub(super) fn collect_broken_links(vex_dir: &Path) -> (Vec<String>, bool) {
     links::collect_broken_links(vex_dir)
 }
 
+pub(crate) fn repair_broken_links(vex_dir: &Path) -> Vec<String> {
+    links::repair_broken_links(vex_dir)
+}
+
 pub(super) fn collect_failed_binaries(bin_dir: &Path) -> Vec<String> {
     binaries::collect_failed_binaries(bin_dir)
 }

--- a/src/commands/doctor/checks/system/filesystem/links.rs
+++ b/src/commands/doctor/checks/system/filesystem/links.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub(super) fn collect_broken_links(vex_dir: &Path) -> (Vec<String>, bool) {
     let mut broken_links = Vec::new();
@@ -19,6 +19,45 @@ pub(super) fn collect_broken_links(vex_dir: &Path) -> (Vec<String>, bool) {
     );
 
     (broken_links, corepack_missing)
+}
+
+/// Walk `~/.vex/current` and `~/.vex/bin`, delete any symlink whose target
+/// no longer exists, and return the labels (e.g. `bin/node`) of what was removed.
+pub(crate) fn repair_broken_links(vex_dir: &Path) -> Vec<String> {
+    let mut removed = Vec::new();
+    repair_broken_link_entries(&vex_dir.join("current"), "current", &mut removed);
+    repair_broken_link_entries(&vex_dir.join("bin"), "bin", &mut removed);
+    removed
+}
+
+fn repair_broken_link_entries(dir: &Path, prefix: &str, removed: &mut Vec<String>) {
+    for path in iter_broken_links(dir) {
+        let label = path
+            .file_name()
+            .map(|n| format!("{}/{}", prefix, n.to_string_lossy()))
+            .unwrap_or_else(|| format!("{}/<unknown>", prefix));
+        if fs::remove_file(&path).is_ok() {
+            removed.push(label);
+        }
+    }
+}
+
+fn iter_broken_links(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    if !dir.exists() {
+        return out;
+    }
+    let Ok(entries) = fs::read_dir(dir) else {
+        return out;
+    };
+    for entry in entries.filter_map(|entry| entry.ok()) {
+        let path = entry.path();
+        // Must be a symlink AND must fail to canonicalize (target gone).
+        if fs::read_link(&path).is_ok() && path.canonicalize().is_err() {
+            out.push(path);
+        }
+    }
+    out
 }
 
 fn collect_broken_link_entries(

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -33,3 +33,7 @@ pub fn run(
 
     setup::init_vex(shell.unwrap_or("skip"), dry_run)
 }
+
+pub fn run_uninit(shell: Option<&str>, dry_run: bool) -> Result<()> {
+    setup::uninit_vex(shell.unwrap_or("auto"), dry_run)
+}

--- a/src/commands/init/setup.rs
+++ b/src/commands/init/setup.rs
@@ -2,13 +2,15 @@ mod home;
 mod integration;
 mod messaging;
 
-use crate::error::Result;
+use crate::error::{Result, VexError};
 use crate::paths::vex_dir;
+use crate::shell;
 use home::initialize_vex_home;
-use integration::{configure_shell_integration, resolve_shell};
+use integration::{configure_shell_integration, remove_shell_integration_block, resolve_shell};
 use messaging::{
     print_home_init_message, print_manual_shell_instructions, print_skip_instructions,
 };
+use owo_colors::OwoColorize;
 
 pub(super) fn init_vex(shell_arg: &str, dry_run: bool) -> Result<()> {
     let vex_dir = vex_dir()?;
@@ -26,4 +28,52 @@ pub(super) fn init_vex(shell_arg: &str, dry_run: bool) -> Result<()> {
             Ok(())
         }
     }
+}
+
+pub(super) fn uninit_vex(shell_arg: &str, dry_run: bool) -> Result<()> {
+    let Some(shell_name) = resolve_shell(shell_arg)? else {
+        println!(
+            "{} no shell selected — pass --shell zsh|bash|fish|nu to remove the hook",
+            "ℹ".blue()
+        );
+        return Ok(());
+    };
+
+    let config_path = shell::get_shell_config_path(&shell_name).map_err(VexError::Parse)?;
+    if !config_path.exists() {
+        println!(
+            "{} nothing to remove — {} does not exist",
+            "ℹ".blue(),
+            config_path.display().to_string().dimmed()
+        );
+        return Ok(());
+    }
+
+    if dry_run {
+        println!(
+            "{} Would strip vex hook block from {}",
+            "Preview".bright_yellow(),
+            config_path.display().to_string().dimmed()
+        );
+        return Ok(());
+    }
+
+    if remove_shell_integration_block(&config_path)? {
+        println!(
+            "{} Removed vex shell integration from {}",
+            "✓".green(),
+            config_path.display().to_string().dimmed()
+        );
+        println!(
+            "  Restart your shell or run `exec {}` for the change to take effect.",
+            shell_name
+        );
+    } else {
+        println!(
+            "{} no vex hook block found in {}",
+            "ℹ".blue(),
+            config_path.display().to_string().dimmed()
+        );
+    }
+    Ok(())
 }

--- a/src/commands/init/setup/integration.rs
+++ b/src/commands/init/setup/integration.rs
@@ -5,6 +5,10 @@ use crate::shell;
 use owo_colors::OwoColorize;
 use std::fs;
 
+/// Marker lines wrapped around the vex hook so we can find and remove it cleanly.
+pub(crate) const HOOK_BEGIN_MARKER: &str = "# >>> vex initialize >>>";
+pub(crate) const HOOK_END_MARKER: &str = "# <<< vex initialize <<<";
+
 pub(super) fn resolve_shell(shell_arg: &str) -> Result<Option<String>> {
     match shell_arg {
         "auto" => Ok(config::default_shell()?.or_else(shell::detect_shell)),
@@ -64,17 +68,132 @@ pub(super) fn configure_shell_integration(shell_name: &str, dry_run: bool) -> Re
 }
 
 fn shell_hook_command(shell_name: &str) -> Result<String> {
-    match shell_name {
-        "zsh" => Ok("\n# vex shell integration\neval \"$(vex env zsh)\"\n".to_string()),
-        "bash" => Ok("\n# vex shell integration\neval \"$(vex env bash)\"\n".to_string()),
-        "fish" => Ok("\n# vex shell integration\nvex env fish | source\n".to_string()),
-        "nu" | "nushell" => Ok(
-            "\n# vex shell integration\nvex env nu | save -f ~/.vex-env.nu\nsource ~/.vex-env.nu\n"
-                .to_string(),
-        ),
-        _ => Err(VexError::Parse(format!(
-            "Unsupported shell: {}",
-            shell_name
-        ))),
+    let body = match shell_name {
+        "zsh" => "eval \"$(vex env zsh)\"".to_string(),
+        "bash" => "eval \"$(vex env bash)\"".to_string(),
+        "fish" => "vex env fish | source".to_string(),
+        "nu" | "nushell" => "vex env nu | save -f ~/.vex-env.nu\nsource ~/.vex-env.nu".to_string(),
+        _ => {
+            return Err(VexError::Parse(format!(
+                "Unsupported shell: {}",
+                shell_name
+            )));
+        }
+    };
+
+    Ok(format!(
+        "\n{begin}\n# vex shell integration (managed by `vex init` / `vex uninit`)\n{body}\n{end}\n",
+        begin = HOOK_BEGIN_MARKER,
+        body = body,
+        end = HOOK_END_MARKER,
+    ))
+}
+
+/// Remove the vex-managed hook block from a shell config file.
+///
+/// Returns `true` when content was removed, `false` when no marker block was found.
+/// Falls back to stripping legacy unmarked hook lines for backwards compatibility.
+pub(crate) fn remove_shell_integration_block(path: &std::path::Path) -> Result<bool> {
+    if !path.exists() {
+        return Ok(false);
+    }
+    let original = fs::read_to_string(path)?;
+    let (stripped, removed) = strip_hook_block(&original);
+    if !removed {
+        return Ok(false);
+    }
+    fs::write(path, stripped)?;
+    Ok(true)
+}
+
+fn strip_hook_block(content: &str) -> (String, bool) {
+    let mut out = String::with_capacity(content.len());
+    let mut in_block = false;
+    let mut removed = false;
+    let mut legacy_skip_body = false;
+
+    for line in content.split_inclusive('\n') {
+        let trimmed = line.trim_end_matches(['\n', '\r']);
+        if !in_block && trimmed.trim() == HOOK_BEGIN_MARKER {
+            in_block = true;
+            removed = true;
+            continue;
+        }
+        if in_block {
+            if trimmed.trim() == HOOK_END_MARKER {
+                in_block = false;
+            }
+            continue;
+        }
+
+        // Legacy: pre-marker installs wrote an unmarked block:
+        //   # vex shell integration
+        //   eval "$(vex env zsh)"   (or fish/nu/nu equivalent)
+        if legacy_skip_body {
+            if is_legacy_hook_body(trimmed.trim()) {
+                removed = true;
+                continue;
+            }
+            legacy_skip_body = false;
+        }
+        if trimmed.trim() == "# vex shell integration" {
+            legacy_skip_body = true;
+            removed = true;
+            continue;
+        }
+
+        out.push_str(line);
+    }
+
+    // Collapse trailing blank lines introduced by the removal.
+    let trimmed_out = out.trim_end_matches('\n').to_string() + "\n";
+    (if removed { trimmed_out } else { out }, removed)
+}
+
+fn is_legacy_hook_body(line: &str) -> bool {
+    matches!(
+        line,
+        "eval \"$(vex env zsh)\""
+            | "eval \"$(vex env bash)\""
+            | "vex env fish | source"
+            | "vex env nu | save -f ~/.vex-env.nu"
+            | "source ~/.vex-env.nu"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_marker_block() {
+        let input = "alpha\n# >>> vex initialize >>>\n# vex shell integration\neval \"$(vex env zsh)\"\n# <<< vex initialize <<<\nbeta\n";
+        let (out, removed) = strip_hook_block(input);
+        assert!(removed);
+        assert_eq!(out, "alpha\nbeta\n");
+    }
+
+    #[test]
+    fn strips_legacy_two_line_block() {
+        let input = "alpha\n# vex shell integration\neval \"$(vex env zsh)\"\nbeta\n";
+        let (out, removed) = strip_hook_block(input);
+        assert!(removed);
+        assert_eq!(out, "alpha\nbeta\n");
+    }
+
+    #[test]
+    fn strips_legacy_nushell_block() {
+        let input = "alpha\n# vex shell integration\nvex env nu | save -f ~/.vex-env.nu\nsource ~/.vex-env.nu\nbeta\n";
+        let (out, removed) = strip_hook_block(input);
+        assert!(removed);
+        assert_eq!(out, "alpha\nbeta\n");
+    }
+
+    #[test]
+    fn untouched_when_no_block() {
+        let input = "alpha\nbeta\n";
+        let (out, removed) = strip_hook_block(input);
+        assert!(!removed);
+        assert_eq!(out, input);
     }
 }

--- a/src/commands/manage/uninstall.rs
+++ b/src/commands/manage/uninstall.rs
@@ -1,7 +1,9 @@
+use crate::alias::AliasManager;
 use crate::error::{Result, VexError};
 use crate::paths::vex_dir;
 use crate::spec::parse_spec;
 use crate::tools;
+use crate::version_files;
 use owo_colors::OwoColorize;
 use std::fs;
 
@@ -36,6 +38,8 @@ pub fn uninstall(tool_name: &str, version: &str) -> Result<()> {
         remove_active_links(&vex_dir, tool_name)?;
     }
 
+    prune_dangling_references(&vex_dir, tool_name, version)?;
+
     println!(
         "{} Uninstalled {} {}",
         "✓".green(),
@@ -43,6 +47,85 @@ pub fn uninstall(tool_name: &str, version: &str) -> Result<()> {
         version.yellow()
     );
     Ok(())
+}
+
+/// Remove vex-owned references to the just-uninstalled `tool@version`.
+///
+/// Touches only files vex itself manages:
+/// - `~/.vex/aliases.toml` global aliases
+/// - `~/.vex/tool-versions` global pin
+///
+/// Project-level `.tool-versions` lives under user/team control, so we only warn
+/// when one nearby still pins the removed version.
+fn prune_dangling_references(
+    vex_dir: &std::path::Path,
+    tool_name: &str,
+    version: &str,
+) -> Result<()> {
+    let manager = AliasManager::new(vex_dir);
+    let removed_aliases = manager.prune_global_for_version(tool_name, version)?;
+    for alias in &removed_aliases {
+        println!(
+            "  {} dropped global alias {}@{}",
+            "·".dimmed(),
+            tool_name,
+            alias
+        );
+    }
+
+    let global_pin = vex_dir.join("tool-versions");
+    if version_files::remove_tool_version_if_matches(&global_pin, tool_name, version)? {
+        println!(
+            "  {} cleared {} from {}",
+            "·".dimmed(),
+            tool_name,
+            global_pin.display().to_string().dimmed()
+        );
+    }
+
+    if let Some(local) = find_local_tool_version_pin(
+        &std::env::current_dir().unwrap_or_default(),
+        tool_name,
+        version,
+    ) {
+        eprintln!(
+            "  {} {} still pins {}@{} — leaving it alone (project files are user-owned)",
+            "!".yellow(),
+            local.display(),
+            tool_name,
+            version
+        );
+    }
+
+    Ok(())
+}
+
+fn find_local_tool_version_pin(
+    start_dir: &std::path::Path,
+    tool_name: &str,
+    version: &str,
+) -> Option<std::path::PathBuf> {
+    let mut dir = start_dir.to_path_buf();
+    loop {
+        let candidate = dir.join(".tool-versions");
+        if candidate.is_file() {
+            if let Ok(content) = std::fs::read_to_string(&candidate) {
+                if content.lines().any(|line| {
+                    let trimmed = line.trim();
+                    if trimmed.is_empty() || trimmed.starts_with('#') {
+                        return false;
+                    }
+                    let mut parts = trimmed.split_whitespace();
+                    parts.next() == Some(tool_name) && parts.next() == Some(version)
+                }) {
+                    return Some(candidate);
+                }
+            }
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
 }
 
 fn active_version_matches(

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -19,8 +19,21 @@ pub(super) const TOOL_VERSION_FILES: &[(&str, &str)] = &[
     (".go-version", "go"),
     (".java-version", "java"),
     (".rust-toolchain", "rust"),
+    ("rust-toolchain", "rust"),
+    (".rust-toolchain.toml", "rust"),
+    ("rust-toolchain.toml", "rust"),
     (".python-version", "python"),
 ];
+
+/// Extract the toolchain channel from a `rust-toolchain.toml` file body.
+///
+/// Supports the rustup `[toolchain] channel = "..."` form. Returns `None` when the
+/// file is malformed or the channel key is missing.
+pub fn parse_rust_toolchain_toml(content: &str) -> Option<String> {
+    let value: toml::Value = toml::from_str(content).ok()?;
+    let channel = value.get("toolchain")?.get("channel")?.as_str()?.trim();
+    (!channel.is_empty()).then(|| channel.to_string())
+}
 
 /// Parse .tool-versions file content
 pub fn parse_tool_versions(content: &str) -> Vec<(String, String)> {

--- a/src/resolver/discovery/files.rs
+++ b/src/resolver/discovery/files.rs
@@ -1,3 +1,4 @@
+use crate::resolver::parse_rust_toolchain_toml;
 use crate::resolver::parse_tool_versions;
 use crate::resolver::TOOL_VERSION_FILES;
 use std::collections::HashMap;
@@ -22,6 +23,9 @@ pub(super) fn find_tool_specific_version_file(dir: &Path, tool_name: &str) -> Op
 
 pub(super) fn read_language_version_file(path: &Path) -> Option<String> {
     let content = fs::read_to_string(path).ok()?;
+    if path.extension().and_then(|s| s.to_str()) == Some("toml") {
+        return parse_rust_toolchain_toml(&content);
+    }
     let version = content.trim().to_string();
     (!version.is_empty()).then_some(version)
 }

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -187,6 +187,35 @@ fn test_resolve_version_rust_toolchain() {
 }
 
 #[test]
+fn test_parse_rust_toolchain_toml_channel() {
+    let content = r#"
+[toolchain]
+channel = "1.76.0"
+components = ["rustfmt"]
+"#;
+
+    assert_eq!(parse_rust_toolchain_toml(content), Some("1.76.0".into()));
+}
+
+#[test]
+fn test_resolve_version_rust_toolchain_toml() {
+    let dir = std::env::temp_dir().join("vex_test_rust_toolchain_toml");
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+
+    fs::write(
+        dir.join("rust-toolchain.toml"),
+        "[toolchain]\nchannel = \"stable\"\n",
+    )
+    .unwrap();
+
+    let result = resolve_version("rust", &dir);
+    assert_eq!(result, Some("stable".into()));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn test_resolve_version_python_version() {
     let dir = std::env::temp_dir().join("vex_test_python_version");
     let _ = fs::remove_dir_all(&dir);

--- a/src/tools/java.rs
+++ b/src/tools/java.rs
@@ -101,25 +101,48 @@ impl Tool for JavaTool {
 
     fn managed_environment(
         &self,
-        _vex_dir: &std::path::Path,
+        vex_dir: &std::path::Path,
         install_dir: Option<&std::path::Path>,
     ) -> ToolEnvironment {
         let Some(install_dir) = install_dir else {
             return ToolEnvironment::default();
         };
 
+        let maven_repo = vex_dir.join("maven/repository");
+        let gradle_home = vex_dir.join("gradle");
+        let maven_opts = format!("-Dmaven.repo.local={}", maven_repo.display());
+
         ToolEnvironment {
-            managed_env: BTreeMap::from([(
-                "JAVA_HOME".to_string(),
-                install_dir.join("Contents/Home").display().to_string(),
-            )]),
+            managed_env: BTreeMap::from([
+                (
+                    "JAVA_HOME".to_string(),
+                    install_dir.join("Contents/Home").display().to_string(),
+                ),
+                ("MAVEN_OPTS".to_string(), maven_opts),
+                (
+                    "GRADLE_USER_HOME".to_string(),
+                    gradle_home.display().to_string(),
+                ),
+                // Neutralize host JVM option globals so vex Java behaves predictably.
+                ("JAVA_TOOL_OPTIONS".to_string(), String::new()),
+                ("_JAVA_OPTIONS".to_string(), String::new()),
+            ]),
             managed_user_bin_dirs: Vec::new(),
-            owned_home_dirs: Vec::new(),
+            owned_home_dirs: vec![
+                maven_repo.display().to_string(),
+                gradle_home.display().to_string(),
+            ],
             project_owned_dirs: Vec::new(),
         }
     }
 
     fn managed_env_keys(&self) -> Vec<&'static str> {
-        vec!["JAVA_HOME"]
+        vec![
+            "JAVA_HOME",
+            "MAVEN_OPTS",
+            "GRADLE_USER_HOME",
+            "JAVA_TOOL_OPTIONS",
+            "_JAVA_OPTIONS",
+        ]
     }
 }

--- a/src/tools/java/tests.rs
+++ b/src/tools/java/tests.rs
@@ -38,6 +38,34 @@ fn test_checksum_url_is_none() {
 }
 
 #[test]
+fn test_managed_environment_sets_build_tool_state() {
+    let vex = std::path::Path::new("/tmp/vex-home");
+    let install = std::path::Path::new("/tmp/vex-home/toolchains/java/21.0.10");
+    let env = JavaTool.managed_environment(vex, Some(install));
+
+    assert_eq!(
+        env.managed_env.get("JAVA_HOME").map(String::as_str),
+        Some("/tmp/vex-home/toolchains/java/21.0.10/Contents/Home")
+    );
+    assert_eq!(
+        env.managed_env.get("MAVEN_OPTS").map(String::as_str),
+        Some("-Dmaven.repo.local=/tmp/vex-home/maven/repository")
+    );
+    assert_eq!(
+        env.managed_env.get("GRADLE_USER_HOME").map(String::as_str),
+        Some("/tmp/vex-home/gradle")
+    );
+    assert_eq!(
+        env.managed_env.get("JAVA_TOOL_OPTIONS").map(String::as_str),
+        Some("")
+    );
+    assert_eq!(
+        env.managed_env.get("_JAVA_OPTIONS").map(String::as_str),
+        Some("")
+    );
+}
+
+#[test]
 fn test_lts_versions_falls_back_to_most_recent_lts() {
     let releases = AvailableReleases {
         available_lts_releases: Vec::new(),

--- a/src/tools/python.rs
+++ b/src/tools/python.rs
@@ -180,6 +180,9 @@ impl Tool for PythonTool {
                     "PYTHONUSERBASE".to_string(),
                     user_base_dir(vex_dir).display().to_string(),
                 ),
+                // Prevent system Python site-packages from leaking into vex Python.
+                ("PYTHONPATH".to_string(), String::new()),
+                ("PYTHONNOUSERSITE".to_string(), "1".to_string()),
             ]),
             managed_user_bin_dirs,
             owned_home_dirs: vec![
@@ -192,6 +195,11 @@ impl Tool for PythonTool {
     }
 
     fn managed_env_keys(&self) -> Vec<&'static str> {
-        vec!["PIP_CACHE_DIR", "PYTHONUSERBASE"]
+        vec![
+            "PIP_CACHE_DIR",
+            "PYTHONUSERBASE",
+            "PYTHONPATH",
+            "PYTHONNOUSERSITE",
+        ]
     }
 }

--- a/src/tools/python/tests.rs
+++ b/src/tools/python/tests.rs
@@ -79,6 +79,14 @@ fn test_managed_environment_sets_official_pip_state() {
         env.managed_env.get("PIP_CACHE_DIR").map(String::as_str),
         Some("/tmp/vex-home/pip/cache")
     );
+    assert_eq!(
+        env.managed_env.get("PYTHONPATH").map(String::as_str),
+        Some("")
+    );
+    assert_eq!(
+        env.managed_env.get("PYTHONNOUSERSITE").map(String::as_str),
+        Some("1")
+    );
     assert!(env
         .managed_user_bin_dirs
         .contains(&"/tmp/vex-home/python/user/bin".to_string()));

--- a/src/version_files.rs
+++ b/src/version_files.rs
@@ -7,6 +7,68 @@ enum VersionFileFormat {
     SingleValue,
 }
 
+/// Remove a tool line from a `.tool-versions`-style file if it pins `expected_version`.
+///
+/// Returns `true` when the file was rewritten. Single-value files (`.python-version` etc.)
+/// are deleted instead, since their entire body represents the pinned version.
+pub fn remove_tool_version_if_matches(
+    file_path: &Path,
+    tool_name: &str,
+    expected_version: &str,
+) -> Result<bool> {
+    if !file_path.exists() {
+        return Ok(false);
+    }
+
+    match version_file_format(file_path) {
+        VersionFileFormat::ToolVersions => {
+            let Ok(existing) = fs::read_to_string(file_path) else {
+                return Ok(false);
+            };
+
+            let mut rewritten = Vec::new();
+            let mut removed = false;
+            for line in existing.lines() {
+                if let Some(parts) = parse_tool_line(line) {
+                    if parts.tool == tool_name {
+                        // Extract the version token from the original line.
+                        let rest = &line[parts.leading.len() + parts.tool.len()..];
+                        let value = rest.split_whitespace().next().unwrap_or_default();
+                        if value == expected_version {
+                            removed = true;
+                            continue;
+                        }
+                    }
+                }
+                rewritten.push(line.to_string());
+            }
+
+            if !removed {
+                return Ok(false);
+            }
+
+            let body = if rewritten.is_empty() {
+                String::new()
+            } else {
+                rewritten.join("\n") + "\n"
+            };
+            fs::write(file_path, body)?;
+            Ok(true)
+        }
+        VersionFileFormat::SingleValue => {
+            let Ok(content) = fs::read_to_string(file_path) else {
+                return Ok(false);
+            };
+            if content.trim() == expected_version {
+                fs::remove_file(file_path)?;
+                Ok(true)
+            } else {
+                Ok(false)
+            }
+        }
+    }
+}
+
 pub fn write_tool_version(file_path: &Path, tool_name: &str, version: &str) -> Result<()> {
     let content = match version_file_format(file_path) {
         VersionFileFormat::ToolVersions => {
@@ -194,6 +256,44 @@ mod tests {
 
         let content = fs::read_to_string(&file_path).unwrap();
         assert_eq!(content, "node 22.0.0 # lts\n");
+    }
+
+    #[test]
+    fn test_remove_tool_version_strips_matching_line() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join(".tool-versions");
+
+        fs::write(&file_path, "node 20.11.0\ngo 1.23.5\n").unwrap();
+        let removed = remove_tool_version_if_matches(&file_path, "node", "20.11.0").unwrap();
+
+        assert!(removed);
+        let content = fs::read_to_string(&file_path).unwrap();
+        assert_eq!(content, "go 1.23.5\n");
+    }
+
+    #[test]
+    fn test_remove_tool_version_keeps_other_versions() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join(".tool-versions");
+
+        fs::write(&file_path, "node 22.0.0\n").unwrap();
+        let removed = remove_tool_version_if_matches(&file_path, "node", "20.11.0").unwrap();
+
+        assert!(!removed);
+        let content = fs::read_to_string(&file_path).unwrap();
+        assert_eq!(content, "node 22.0.0\n");
+    }
+
+    #[test]
+    fn test_remove_single_value_file_when_match() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join(".python-version");
+
+        fs::write(&file_path, "3.12.1\n").unwrap();
+        let removed = remove_tool_version_if_matches(&file_path, "python", "3.12.1").unwrap();
+
+        assert!(removed);
+        assert!(!file_path.exists());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `vex uninit` for removing managed shell hooks, including legacy hook snippets
- add `vex doctor --repair`, uninstall reference cleanup, archive-cache size pruning, and Rust toolchain TOML discovery
- tighten Java/Python activation isolation and update user docs/changelog for the new recovery behavior

## Validation
- `cargo fmt --all --check`
- `git diff --check`
- `RUSTC=/Users/qinfuyao/.vex/toolchains/rust/1.95.0/rustc/bin/rustc PATH=/Users/qinfuyao/.vex/toolchains/rust/1.95.0/cargo/bin:/Users/qinfuyao/.vex/toolchains/rust/1.95.0/rustc/bin:/Users/qinfuyao/.vex/toolchains/rust/1.95.0/clippy-preview/bin:/Users/qinfuyao/.vex/toolchains/rust/1.95.0/rustfmt-preview/bin:$PATH cargo test --all-features --bin vex -- --test-threads=1`
- `RUSTC=/Users/qinfuyao/.vex/toolchains/rust/1.95.0/rustc/bin/rustc PATH=/Users/qinfuyao/.vex/toolchains/rust/1.95.0/cargo/bin:/Users/qinfuyao/.vex/toolchains/rust/1.95.0/rustc/bin:/Users/qinfuyao/.vex/toolchains/rust/1.95.0/clippy-preview/bin:/Users/qinfuyao/.vex/toolchains/rust/1.95.0/rustfmt-preview/bin:$PATH cargo clippy --all-targets --all-features -- -D warnings`

Note: after rebasing onto `origin/main`, local Rust 1.94.1 could not build `sysinfo@0.39.2` because it now requires rustc 1.95, so validation used a no-switch `vex install rust@1.95.0 --no-switch` toolchain.