### PR TITLE
deps: bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2047,9 +2047,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
quinn-proto 0.11.14 is affected by RUSTSEC-2026-0185 (remote memory exhaustion via unbounded out-of-order stream reassembly, GHSA-4w2j-m93h-cj5j). Patch release 0.11.15 fixes it; dependency set is unchanged between the two versions. This unblocks the Security Audit CI gate, which is currently failing on main.